### PR TITLE
Correctly handle null from PartitionReceiver.receive.

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsClientWrapper.scala
+++ b/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsClientWrapper.scala
@@ -124,10 +124,8 @@ class EventHubsClientWrapper extends Serializable {
   }
 
   def receive(): Iterable[EventData] = {
-
-    val receivedEvents: Iterable[EventData] = eventhubsReceiver.receive(MAXIMUM_EVENT_RATE).get().asScala
-
-    if (receivedEvents == null) List.empty[EventData] else receivedEvents
+    val events = eventhubsReceiver.receive(MAXIMUM_EVENT_RATE).get()
+    if (events == null) Iterable.empty else events.asScala
   }
 
   def close(): Unit = if(eventhubsReceiver != null) eventhubsReceiver.close()


### PR DESCRIPTION
This fixes `EventHubsClientWrapper.receive` to correctly handle a null returned from `PartitionReceiver.receive` when converting the `java.lang.Iterable` to a `scala.Iterable`.