### PR TITLE
fix the flaky test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spark-eventhubs
+# spark-eventhubs [![Build Status](https://travis-ci.org/hdinsight/spark-eventhubs.svg?branch=master)](https://travis-ci.org/hdinsight/spark-eventhubs)
 This is the source code of EventHubsReceiver for Spark Streaming. 
 
 [Here](https://github.com/hdinsight/spark-streaming-data-persistence-examples) is an example project that uses EventHubsReceiver to count and persist messages from Azure Eventhubs.

--- a/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
+++ b/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
@@ -45,7 +45,7 @@ private[eventhubs] class EventHubsReceiver(
    * Note we cannot use Receiver.isStopped() because there could be race condition when the
    * MessageHandler thread is started the state of the receiver has not been updated yet.
    */
-  private var stopMessageHandler = false
+  @volatile private var stopMessageHandler = false
 
   /**
    * The latest sequence number this receiver has seen in messages from EventHubs.

--- a/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiverSuite.scala
+++ b/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiverSuite.scala
@@ -110,6 +110,8 @@ class EventHubsReceiverSuite extends TestSuiteBase with MockitoSugar{
     Thread sleep eventCheckpointIntervalInSeconds * 1000
     receiver.onStop()
 
+    Thread sleep eventCheckpointIntervalInSeconds * 1000
+
     verify(offsetStoreMock, times(1)).open()
     verify(offsetStoreMock, times(1)).write(eventOffset)
     verify(offsetStoreMock, times(1)).close()


### PR DESCRIPTION
This PR fix the flaky test in receiver based eventhub spark streaming "EventHubsReceiver can receive message with proper checkpointing"

The major changes include:

1. stopHandler variable shall be volatile as it is shared by two different threads

2. We shall give the main thread a pause before checking whether the MessageHandler thread made the expected function calls
