### PR TITLE
Checkpoint race condition bug

### DIFF
--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -265,7 +265,6 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
   override def compute(validTime: Time): Option[RDD[EventData]] = {
     if (!initialized) {
       ProgressTrackingListener.initInstance(ssc, progressDir)
-      initialized = true
     }
     require(progressTracker != null, "ProgressTracker hasn't been initialized")
     val latestOffsetOfAllPartitions = fetchLatestOffset(validTime)
@@ -277,7 +276,9 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
     } else {
       var startPointInNextBatch = fetchStartOffsetForEachPartition(validTime)
       while (startPointInNextBatch.equals(currentOffsetsAndSeqNums) &&
-        !startPointInNextBatch.equals(latestOffsetOfAllPartitions) && !consumedAllMessages) {
+        !startPointInNextBatch.equals(latestOffsetOfAllPartitions) &&
+        !consumedAllMessages &&
+        initialized) {
         logInfo(s"wait for ProgressTrackingListener to commit offsets at Batch" +
           s" ${validTime.milliseconds}")
         graph.wait()
@@ -290,6 +291,7 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
       } else {
         consumedAllMessages = false
       }
+      initialized = true
       proceedWithNonEmptyRDD(validTime, startPointInNextBatch, latestOffsetOfAllPartitions)
     }
   }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -277,8 +277,8 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
       var startPointInNextBatch = fetchStartOffsetForEachPartition(validTime)
       while (startPointInNextBatch.equals(currentOffsetsAndSeqNums) &&
         !startPointInNextBatch.equals(latestOffsetOfAllPartitions) &&
-        !consumedAllMessages) {// &&
-        // initialized) {
+        !consumedAllMessages &&
+        initialized) {
         logInfo(s"wait for ProgressTrackingListener to commit offsets at Batch" +
           s" ${validTime.milliseconds}")
         graph.wait()

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -277,8 +277,8 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
       var startPointInNextBatch = fetchStartOffsetForEachPartition(validTime)
       while (startPointInNextBatch.equals(currentOffsetsAndSeqNums) &&
         !startPointInNextBatch.equals(latestOffsetOfAllPartitions) &&
-        !consumedAllMessages &&
-        initialized) {
+        !consumedAllMessages) {// &&
+        // initialized) {
         logInfo(s"wait for ProgressTrackingListener to commit offsets at Batch" +
           s" ${validTime.milliseconds}")
         graph.wait()

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -274,7 +274,8 @@ class ProgressTrackingAndCheckpointSuite extends CheckpointAndProgressTrackerTes
       Seq(7, 8, 9, 1, 2, 3, 4, 5, 6, 7))
     val expectedOutputBeforeRestart = Seq(
       Seq(2, 3, 5, 6, 8, 9), Seq(4, 5, 7, 8, 10, 2), Seq(6, 7, 9, 10, 3, 4))
-    val expectedOutputAfterRestart = Seq(Seq(8, 9, 11, 2, 5, 6), Seq(10, 11, 3, 4, 7, 8))
+    val expectedOutputAfterRestart = Seq(
+      Seq(6, 7, 9, 10, 3, 4), Seq(8, 9, 11, 2, 5, 6), Seq(10, 11, 3, 4, 7, 8))
 
     testUnaryOperation(
       input,

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -315,22 +315,9 @@ class ProgressTrackingAndCheckpointSuite extends CheckpointAndProgressTrackerTes
         EventHubNameAndPartition("eh1", 1) -> (5L, 5L),
         EventHubNameAndPartition("eh1", 2) -> (5L, 5L))
 
-    testUnaryOperation(
-      input,
-      eventhubsParams = Map[String, Map[String, String]](
-        "eh1" -> Map(
-          "eventhubs.partition.count" -> "3",
-          "eventhubs.maxRate" -> "2",
-          "eventhubs.name" -> "eh1")
-      ),
-      expectedOffsetsAndSeqs = Map(eventhubNamespace ->
-        Map(EventHubNameAndPartition("eh1", 0) -> (7L, 7L),
-          EventHubNameAndPartition("eh1", 1) -> (7L, 7L),
-          EventHubNameAndPartition("eh1", 2) -> (7L, 7L))
-      ),
-      operation = (inputDStream: EventHubDirectDStream) =>
-        inputDStream.map(eventData => eventData.getProperties.get("output").toInt + 1),
-      expectedOutputAfterRestart)
+    runStreamsWithEventHubInput(ssc,
+      expectedOutputAfterRestart.length - 1,
+      expectedOutputAfterRestart, useSet = true)
 
     testProgressTracker(
       eventhubNamespace,

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -267,6 +267,79 @@ class ProgressTrackingAndCheckpointSuite extends CheckpointAndProgressTrackerTes
       7000L)
   }
 
+  test("always start the first micro batch") {
+    val input = Seq(
+      Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+      Seq(4, 5, 6, 7, 8, 9, 10, 1, 2, 3),
+      Seq(7, 8, 9, 1, 2, 3, 4, 5, 6, 7))
+    val expectedOutputBeforeRestart = Seq(
+      Seq(2, 3, 5, 6, 8, 9), Seq(4, 5, 7, 8, 10, 2), Seq(6, 7, 9, 10, 3, 4))
+    val expectedOutputAfterRestart = Seq(
+      Seq(8, 9, 11, 2, 5, 6), Seq(10, 11, 3, 4, 7, 8))
+
+    testUnaryOperation(
+      input,
+      eventhubsParams = Map[String, Map[String, String]](
+        "eh1" -> Map(
+          "eventhubs.partition.count" -> "3",
+          "eventhubs.maxRate" -> "2",
+          "eventhubs.name" -> "eh1")
+      ),
+      expectedOffsetsAndSeqs = Map(eventhubNamespace ->
+        Map(EventHubNameAndPartition("eh1", 0) -> (3L, 3L),
+          EventHubNameAndPartition("eh1", 1) -> (3L, 3L),
+          EventHubNameAndPartition("eh1", 2) -> (3L, 3L))
+      ),
+      operation = (inputDStream: EventHubDirectDStream) =>
+        inputDStream.map(eventData => eventData.getProperties.get("output").toInt + 1),
+      expectedOutputBeforeRestart)
+
+    testProgressTracker(
+      eventhubNamespace,
+      expectedOffsetsAndSeqs = Map(EventHubNameAndPartition("eh1", 0) -> (5L, 5L),
+        EventHubNameAndPartition("eh1", 1) -> (5L, 5L),
+        EventHubNameAndPartition("eh1", 2) -> (5L, 5L)),
+      4000L)
+
+    val currentCheckpointDirectory = ssc.checkpointDir
+
+    ssc.stop()
+    reset()
+
+    ssc = StreamingContext.getOrCreate(currentCheckpointDirectory,
+      () => createContextForCheckpointOperation(batchDuration, checkpointDirectory))
+
+    ssc.graph.getInputStreams().filter(_.isInstanceOf[EventHubDirectDStream]).map(
+      _.asInstanceOf[EventHubDirectDStream]).head.currentOffsetsAndSeqNums =
+      Map(EventHubNameAndPartition("eh1", 0) -> (5L, 5L),
+        EventHubNameAndPartition("eh1", 1) -> (5L, 5L),
+        EventHubNameAndPartition("eh1", 2) -> (5L, 5L))
+
+    testUnaryOperation(
+      input,
+      eventhubsParams = Map[String, Map[String, String]](
+        "eh1" -> Map(
+          "eventhubs.partition.count" -> "3",
+          "eventhubs.maxRate" -> "2",
+          "eventhubs.name" -> "eh1")
+      ),
+      expectedOffsetsAndSeqs = Map(eventhubNamespace ->
+        Map(EventHubNameAndPartition("eh1", 0) -> (7L, 7L),
+          EventHubNameAndPartition("eh1", 1) -> (7L, 7L),
+          EventHubNameAndPartition("eh1", 2) -> (7L, 7L))
+      ),
+      operation = (inputDStream: EventHubDirectDStream) =>
+        inputDStream.map(eventData => eventData.getProperties.get("output").toInt + 1),
+      expectedOutputAfterRestart)
+
+    testProgressTracker(
+      eventhubNamespace,
+      expectedOffsetsAndSeqs = Map(EventHubNameAndPartition("eh1", 0) -> (9L, 9L),
+        EventHubNameAndPartition("eh1", 1) -> (9L, 9L),
+        EventHubNameAndPartition("eh1", 2) -> (9L, 9L)),
+      7000L)
+  }
+
   test("recover from progress after updating code (no checkpoint provided and roll back)") {
     val input = Seq(
       Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -274,8 +274,7 @@ class ProgressTrackingAndCheckpointSuite extends CheckpointAndProgressTrackerTes
       Seq(7, 8, 9, 1, 2, 3, 4, 5, 6, 7))
     val expectedOutputBeforeRestart = Seq(
       Seq(2, 3, 5, 6, 8, 9), Seq(4, 5, 7, 8, 10, 2), Seq(6, 7, 9, 10, 3, 4))
-    val expectedOutputAfterRestart = Seq(
-      Seq(8, 9, 11, 2, 5, 6), Seq(10, 11, 3, 4, 7, 8))
+    val expectedOutputAfterRestart = Seq(Seq(8, 9, 11, 2, 5, 6), Seq(10, 11, 3, 4, 7, 8))
 
     testUnaryOperation(
       input,


### PR DESCRIPTION
Spark Streaming makes checkpoint for micro batches no matter whether they are successfully processed

Batch 0 -> Success, Batch 1 -> Fail

While the application will be shutdown after the scheduler detects the failure of Batch 1, the checkpoint thread of Spark Streaming is possible to finish checkpointing of Batch 1 before the application ends because they are in different two threads. This makes the implementation of DStream tricky, in terms of that you cannot update any state of DStream before the batch is successfully finished, otherwise, you might have a premature updated state when you recover from the checkpoint 

This PR contains the workaround for this mechanism. 
