### PR TITLE
fix flaky test

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -650,7 +650,6 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
             QueryTest.sameRows(expectedAnswer, sparkAnswer, isSorted).foreach {
               error => failTest(error)
             }
-            println("checking answer")
         }
         pos += 1
       }


### PR DESCRIPTION
close #119

This CR fixes a flaky test caused by the bug in our unit test framework (which was inherited from Spark's test framework)

The reason of the bug is a race condition in the framework. StreamExecution.stop() is called by the test main thread. The implementation of stop() consists of two steps: 1) interrupt microBatchThread, 2) wait for microBatchThread to finish with join(). However, microBatchThread falls into a wait/while loop when the current clock time is less than the next batch time. The expectation is that when the microBatchThread is blocked by wait(), the call of stop() will interrupt it and jump out from the while loop with a InterruptedException

However, the race condition will happen with the following call flow

1. interrupt microBatchThread

2. microBatchThread falls into wait() loop

3. wait for microBatchThread to finish with join()

the execution flow will block at 3 and never proceed until a timeout happens (test failed) 


The other issue in the implementation of Spark's clock is that the variable representing the current time is not volatile, i.e. the threads can have inconsistent version of this variable. Since clock update is executed in test main thread and clock time comparison is in microBatchThread, it will also makes the test fail.
