### PR TITLE
check for null reference in RDD to DataFrame conversion

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -278,7 +278,7 @@ private[spark] class EventHubsSource(
             })
           } else {
             Seq(eventData.getProperties.asScala.map { case (k, v) =>
-              k -> (if (v == null) "" else v.toString) })
+              k -> (if (v == null) null else v.toString) })
           }
         } else {
           Seq()

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -277,7 +277,8 @@ private[spark] class EventHubsSource(
               eventData.getProperties.asScala.getOrElse(k, "").toString
             })
           } else {
-            Seq(eventData.getProperties.asScala.map { case (k, v) => k -> v.toString })
+            Seq(eventData.getProperties.asScala.map { case (k, v) =>
+              k -> (if (v == null) "" else v.toString) })
           }
         } else {
           Seq()


### PR DESCRIPTION
close #121 

If the value is null, I place an empty string in its place. Following the same convention set up on line 277 within the same method. 