### PR TITLE
updating receiver identifier with different info

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -19,9 +19,11 @@ package org.apache.spark.eventhubscommon.client
 import java.time.Instant
 
 import scala.collection.JavaConverters._
+
 import com.microsoft.azure.eventhubs.{EventHubClient => AzureEventHubClient, _}
 import com.microsoft.azure.servicebus._
 import EventHubsOffsetTypes.EventHubsOffsetType
+
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 import org.apache.spark.internal.Logging

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -19,11 +19,10 @@ package org.apache.spark.eventhubscommon.client
 import java.time.Instant
 
 import scala.collection.JavaConverters._
-
 import com.microsoft.azure.eventhubs.{EventHubClient => AzureEventHubClient, _}
 import com.microsoft.azure.servicebus._
 import EventHubsOffsetTypes.EventHubsOffsetType
-
+import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 import org.apache.spark.internal.Logging
 import org.apache.spark.streaming.eventhubs.checkpoint.OffsetStore
@@ -150,7 +149,7 @@ private[spark] class EventHubsClientWrapper extends Serializable with EventHubCl
     val receiverOption = new ReceiverOptions()
     receiverOption.setReceiverRuntimeMetricEnabled(false)
     receiverOption.setIdentifier(
-      s"$consumerGroup-$eventHubsName-$partitionId-$currentOffset")
+      s"${SparkEnv.get.executorId}-${TaskContext.get().taskAttemptId()}")
 
     eventhubsReceiver = offsetType match {
       case EventHubsOffsetTypes.None | EventHubsOffsetTypes.PreviousCheckpoint


### PR DESCRIPTION
close #118 

consumerGroup, eventHubsName, and partitionId already exist in the receiver state without adding them to the receiverIdentifier. Adding spark executorId and spark TaskId, so receivers can be matched with specific tasks and machines. 