### PR TITLE
Slight cleanup to code base 

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubscommon/Implicits.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/Implicits.scala
@@ -56,8 +56,6 @@ private[eventhubscommon] object Implicits {
 
   /**
    * Azure EventHub enabled streaming context
-   *
-   * @param ssc
    */
   class SparkEventHubContext(ssc: StreamingContext) {
     // scalastyle:off

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -20,9 +20,10 @@ import java.time.Instant
 
 import scala.collection.JavaConverters._
 
+import EventHubsOffsetTypes.EventHubsOffsetType
+
 import com.microsoft.azure.eventhubs.{EventHubClient => AzureEventHubClient, _}
 import com.microsoft.azure.servicebus._
-import EventHubsOffsetTypes.EventHubsOffsetType
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapper.scala
@@ -21,7 +21,6 @@ import java.time.Instant
 import scala.collection.JavaConverters._
 
 import EventHubsOffsetTypes.EventHubsOffsetType
-
 import com.microsoft.azure.eventhubs.{EventHubClient => AzureEventHubClient, _}
 import com.microsoft.azure.servicebus._
 

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/RestfulEventHubClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/RestfulEventHubClient.scala
@@ -45,7 +45,7 @@ private[spark] class RestfulEventHubClient(
     eventHubNamespace: String,
     numPartitionsEventHubs: Map[String, Int],
     consumerGroups: Map[String, String],
-    policyKeys: Map[String, String Tuple2 String],
+    policyKeys: Map[String, (String, String)],
     threadNum: Int) extends EventHubClient with Logging {
 
   private val RETRY_INTERVAL_SECONDS = Array(8, 16, 32, 64, 128)
@@ -84,7 +84,7 @@ private[spark] class RestfulEventHubClient(
 
   private def aggregateResults[T](undergoingRequests: List[Future[(EventHubNameAndPartition, T)]]):
       Option[Map[EventHubNameAndPartition, T]] = {
-    Await.ready(Future.sequence(undergoingRequests), 60.seconds).value.get match {
+    Await.ready(Future.sequence(undergoingRequests), 60 seconds).value.get match {
       case Success(queryResponse) =>
         Some(queryResponse.toMap.map {case (eventHubQueryKey, queryResponseString) =>
           (eventHubQueryKey, queryResponseString.asInstanceOf[T])})

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/client/RestfulEventHubClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/client/RestfulEventHubClient.scala
@@ -45,7 +45,7 @@ private[spark] class RestfulEventHubClient(
     eventHubNamespace: String,
     numPartitionsEventHubs: Map[String, Int],
     consumerGroups: Map[String, String],
-    policyKeys: Map[String, Tuple2[String, String]],
+    policyKeys: Map[String, String Tuple2 String],
     threadNum: Int) extends EventHubClient with Logging {
 
   private val RETRY_INTERVAL_SECONDS = Array(8, 16, 32, 64, 128)
@@ -84,7 +84,7 @@ private[spark] class RestfulEventHubClient(
 
   private def aggregateResults[T](undergoingRequests: List[Future[(EventHubNameAndPartition, T)]]):
       Option[Map[EventHubNameAndPartition, T]] = {
-    Await.ready(Future.sequence(undergoingRequests), 60 seconds).value.get match {
+    Await.ready(Future.sequence(undergoingRequests), 60.seconds).value.get match {
       case Success(queryResponse) =>
         Some(queryResponse.toMap.map {case (eventHubQueryKey, queryResponseString) =>
           (eventHubQueryKey, queryResponseString.asInstanceOf[T])})

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/PathTools.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/PathTools.scala
@@ -17,46 +17,53 @@
 
 package org.apache.spark.eventhubscommon.progress
 
+import org.apache.hadoop.fs.Path
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 
 private[spark] object PathTools extends Serializable {
 
-  private def fromSubDirNamesToString(subDirs: Seq[String]): String = {
+  private def combineDirectoryNames(subDirs: Seq[String]): String =
     subDirs.mkString("/")
-  }
 
-  def progressDirPathStr(progressDir: String, subDirNames: String*): String = {
-    s"$progressDir/${fromSubDirNamesToString(subDirNames)}"
-  }
+  private def combineDirectoryNames(dirs: String*)(implicit u: DummyImplicit): String =
+    dirs.mkString("/")
 
-  def progressTempDirPathStr(progressDir: String, subDirNames: String*): String = {
-    s"$progressDir/${fromSubDirNamesToString(subDirNames)}_temp"
-  }
+  def makeProgressDirectoryStr(progressDir: String, subDirNames: String*): String =
+    s"$progressDir/${combineDirectoryNames(subDirNames)}"
 
-  def progressMetadataDirPathStr(progressDir: String, subDirNames: String*): String = {
-    s"$progressDir/${fromSubDirNamesToString(subDirNames)}_metadata"
-  }
+  def makeProgressDirectoryPath(progressDir: String, subDirNames: String*): Path =
+    new Path(s"$progressDir/${combineDirectoryNames(subDirNames)}")
 
-  def progressTempFileNamePattern(
+  def makeTempDirectoryStr(progressDir: String, subDirNames: String*): String =
+    s"$progressDir/${combineDirectoryNames(subDirNames)}_temp"
+
+  def makeTempDirectoryPath(progressDir: String, subDirNames: String*): Path =
+    new Path(s"$progressDir/${combineDirectoryNames(subDirNames)}_temp")
+
+  def makeMetadataDirectoryStr(progressDir: String, subDirNames: String*): String =
+    s"$progressDir/${combineDirectoryNames(subDirNames)}_metadata"
+
+  def makeMetadataDirectoryPath(progressDir: String, subDirNames: String*): Path =
+    new Path(s"$progressDir/${combineDirectoryNames(subDirNames)}_metadata")
+
+  def makeProgressFileName(timestamp: Long): String =
+    s"progress-$timestamp"
+
+  def makeTempFileName(
       streamId: Int,
       uid: String,
       eventHubNameAndPartition: EventHubNameAndPartition,
-      timestamp: Long): String = {
+      timestamp: Long): String =
     s"$streamId-$uid-$eventHubNameAndPartition-$timestamp"
-  }
 
-  def progressFileNamePattern(timestamp: Long): String = {
-    s"progress-$timestamp"
-  }
-
-  def progressMetadataNamePattern(timestamp: Long): String = timestamp.toString
-
-  def progressTempFileStr(
+  def makeTempFilePath(
       basePath: String,
       streamId: Int,
       uid: String,
       eventHubNameAndPartition: EventHubNameAndPartition,
-      timestamp: Long): String = {
-    basePath + "/" + progressTempFileNamePattern(streamId, uid, eventHubNameAndPartition, timestamp)
-  }
+      timestamp: Long): Path =
+    new Path(s"${combineDirectoryNames(
+      basePath, makeTempFileName(streamId, uid, eventHubNameAndPartition, timestamp))}")
+
+  def makeMetadataFileName(timestamp: Long): String = timestamp.toString
 }

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/PathTools.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/PathTools.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.eventhubscommon.progress
 
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
 
 private[spark] object PathTools extends Serializable {

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
@@ -276,8 +276,8 @@ abstract class ProgressTrackerBase[T <: EventHubsConnector](
     var oos: FSDataOutputStream = null
     try {
       // write progress file
-      oos = fs.create(new Path(s"$progressDirectoryPath/${PathTools.makeProgressFileName(commitTime)}"),
-        true)
+      oos = fs.create(new Path(
+        s"$progressDirectoryPath/${PathTools.makeProgressFileName(commitTime)}"), true)
       offsetToCommit.foreach {
         case (namespace, ehNameAndPartitionToOffsetAndSeq) =>
           ehNameAndPartitionToOffsetAndSeq.foreach {
@@ -304,7 +304,8 @@ abstract class ProgressTrackerBase[T <: EventHubsConnector](
   private def createMetadata(fs: FileSystem, commitTime: Long): Boolean = {
     var oos: FSDataOutputStream = null
     try {
-      oos = fs.create(new Path(s"$metadataDirectoryStr/" + s"${PathTools.makeMetadataFileName(commitTime)}"), true)
+      oos = fs.create(new Path(
+        s"$metadataDirectoryStr/" + s"${PathTools.makeMetadataFileName(commitTime)}"), true)
       true
     } catch {
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
@@ -30,16 +30,14 @@ import org.apache.hadoop.fs._
 import org.apache.spark.eventhubscommon.{EventHubNameAndPartition, EventHubsConnector, OffsetRecord}
 import org.apache.spark.internal.Logging
 
-private[spark]
-abstract class ProgressTrackerBase[T <: EventHubsConnector](
+private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     progressDir: String, appName: String, hadoopConfiguration: Configuration) extends Logging {
 
-  private[spark] lazy val progressDirectoryStr =
-    PathTools.makeProgressDirectoryStr(progressDir, appName)
-  private[spark] lazy val tempDirectoryStr =
-    PathTools.makeTempDirectoryStr(progressDir, appName)
-  private[spark] lazy val metadataDirectoryStr =
-    PathTools.makeMetadataDirectoryStr(progressDir, appName)
+  private[spark] lazy val progressDirectoryStr = PathTools.makeProgressDirectoryStr(progressDir,
+    appName)
+  private[spark] lazy val tempDirectoryStr = PathTools.makeTempDirectoryStr(progressDir, appName)
+  private[spark] lazy val metadataDirectoryStr = PathTools.makeMetadataDirectoryStr(progressDir,
+    appName)
 
   private[spark] lazy val progressDirectoryPath = new Path(progressDirectoryStr)
   private[spark] lazy val tempDirectoryPath = new Path(tempDirectoryStr)

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
@@ -273,8 +273,8 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     var oos: FSDataOutputStream = null
     try {
       // write progress file
-      oos = fs.create(new Path(
-        s"$progressDirectoryPath/${PathTools.makeProgressFileName(commitTime)}"), true)
+      oos = fs.create(new Path(s"$progressDirectoryPath/${PathTools.makeProgressFileName(
+        commitTime)}"), true)
       offsetToCommit.foreach {
         case (namespace, ehNameAndPartitionToOffsetAndSeq) =>
           ehNameAndPartitionToOffsetAndSeq.foreach {
@@ -301,8 +301,8 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
   private def createMetadata(fs: FileSystem, commitTime: Long): Boolean = {
     var oos: FSDataOutputStream = null
     try {
-      oos = fs.create(new Path(
-        s"$metadataDirectoryStr/" + s"${PathTools.makeMetadataFileName(commitTime)}"), true)
+      oos = fs.create(new Path(s"$metadataDirectoryStr/" + s"${PathTools.makeMetadataFileName(
+        commitTime)}"), true)
       true
     } catch {
       case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
@@ -30,41 +30,36 @@ import org.apache.hadoop.fs._
 import org.apache.spark.eventhubscommon.{EventHubNameAndPartition, EventHubsConnector, OffsetRecord}
 import org.apache.spark.internal.Logging
 
-private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
+private[spark]
+abstract class ProgressTrackerBase[T <: EventHubsConnector](
     progressDir: String, appName: String, hadoopConfiguration: Configuration) extends Logging {
 
-  protected lazy val progressDirStr: String = PathTools.progressDirPathStr(progressDir, appName)
-  protected lazy val progressTempDirStr: String = PathTools.progressTempDirPathStr(progressDir,
-    appName)
-  protected lazy val progressMetadataDirStr: String = PathTools.progressMetadataDirPathStr(
-    progressDir, appName)
+  private[spark] lazy val progressDirectoryStr =
+    PathTools.makeProgressDirectoryStr(progressDir, appName)
+  private[spark] lazy val tempDirectoryStr =
+    PathTools.makeTempDirectoryStr(progressDir, appName)
+  private[spark] lazy val metadataDirectoryStr =
+    PathTools.makeMetadataDirectoryStr(progressDir, appName)
 
-  protected lazy val progressDirPath = new Path(progressDirStr)
-  protected lazy val progressTempDirPath = new Path(progressTempDirStr)
-  protected lazy val progressMetadataDirPath = new Path(progressMetadataDirStr)
+  private[spark] lazy val progressDirectoryPath = new Path(progressDirectoryStr)
+  private[spark] lazy val tempDirectoryPath = new Path(tempDirectoryStr)
+  private[spark] lazy val metadataDirectoryPath = new Path(metadataDirectoryStr)
 
   def eventHubNameAndPartitions: Map[String, List[EventHubNameAndPartition]]
 
-  private[spark] def progressDirectoryPath = progressDirPath
-  private[spark] def progressTempDirectoryPath = progressTempDirPath
-  private[spark] def progressMetadataDirectoryPath = progressMetadataDirPath
-
-  // metadata cleaning is different with progress file and temporary file clean up in that, metadata
-  // is developed for fast initialization of progress tracker and it should (can) be independent
-  // with Spark Streaming checkpoint (the others have to be coordinated with Spark Streaming
-  // checkpoint cleanup to ensure that we have enough support for recovery). By cleaning metadata
-  // in progress tracker, we can ensure that the ProgressTracker can still be quickly initialized
-  // even the user does not enable Spark Streaming checkpoint or the cleanup of checkpoint is
-  // lagging behind
+  /* Metadata is maintained for fast ProgressTracker initialization and can cleaned independently
+     from Spark checkpoint files. We'll clean metadata here to ensure it's cleaned whether or not
+     Spark checkpointing is enabled.
+   */
   private val threadPoolForMetadataClean = new ScheduledThreadPoolExecutor(1)
   protected val metadataCleanupFuture: ScheduledFuture[_] = scheduleMetadataCleanTask()
 
   // getModificationTime is not reliable for unit test and some extreme case in distributed
   // file system so that we have to derive timestamp from the file names. The timestamp can be the
   // logical one like batch 1, 2, 3 and can also be the real timestamp
-  private[spark] def fromPathToTimestamp(path: Path): Long = {
+  private[spark] def fromPathToTimestamp(path: Path): Long =
     path.getName.split("-").last.toLong
-  }
+
 
   protected def allEventNameAndPartitionExist(
       candidateEhNameAndPartitions: Map[String, List[EventHubNameAndPartition]]): Boolean = {
@@ -75,10 +70,10 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     }
   }
 
-  // no metadata (for backward compatiblity
+  // no metadata (for backward compatibility)
   private def getLatestFileWithoutMetadata(fs: FileSystem, timestamp: Long = Long.MaxValue):
       Option[Path] = {
-    val allFiles = fs.listStatus(progressDirPath)
+    val allFiles = fs.listStatus(progressDirectoryPath)
     if (allFiles.length < 1) {
       None
     } else {
@@ -92,7 +87,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     val latestMetadata = metadataFiles.sortWith((f1, f2) => f1.getPath.getName.toLong >
       f2.getPath.getName.toLong).head
     logInfo(s"locate latest timestamp in metadata as ${latestMetadata.getPath.getName}")
-    Some(new Path(progressDirStr + "/progress-" + latestMetadata.getPath.getName))
+    Some(new Path(progressDirectoryStr + "/progress-" + latestMetadata.getPath.getName))
   }
 
   /**
@@ -103,8 +98,8 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
   private[spark] def getLatestFile(fs: FileSystem, timestamp: Long = Long.MaxValue):
     (Int, Option[Path]) = {
     // first check metadata directory if exists
-    if (fs.exists(progressMetadataDirPath)) {
-      val metadataFiles = fs.listStatus(progressMetadataDirPath).filter(
+    if (fs.exists(metadataDirectoryPath)) {
+      val metadataFiles = fs.listStatus(metadataDirectoryPath).filter(
         file => file.isFile && file.getPath.getName.toLong <= timestamp)
       if (metadataFiles.nonEmpty) {
         // metadata files exists
@@ -207,8 +202,8 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
    */
   private[spark] def pinPointProgressFile(fs: FileSystem, timestamp: Long): Option[Path] = {
     try {
-      require(fs.isDirectory(progressDirPath), s"$progressDirPath is not a directory")
-      val targetFilePath = new Path(s"$progressDirStr/progress-$timestamp")
+      require(fs.isDirectory(progressDirectoryPath), s"$progressDirectoryPath is not a directory")
+      val targetFilePath = new Path(s"$progressDirectoryStr/progress-$timestamp")
       val targetFileExists = fs.exists(targetFilePath)
       if (targetFileExists) Some(targetFilePath) else None
     } catch {
@@ -231,7 +226,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
    * read the progress record for the specified progressEntityID and timestamp
    */
   def read(targetConnectorUID: String, timestamp: Long, fallBack: Boolean): OffsetRecord = {
-    val fs = progressDirPath.getFileSystem(hadoopConfiguration)
+    val fs = progressDirectoryPath.getFileSystem(hadoopConfiguration)
     var recordToReturn = Map[EventHubNameAndPartition, (Long, Long)]()
     var readTimestamp: Long = 0
     var progressFileOption: Option[Path] = null
@@ -281,7 +276,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     var oos: FSDataOutputStream = null
     try {
       // write progress file
-      oos = fs.create(new Path(s"$progressDirStr/${PathTools.progressFileNamePattern(commitTime)}"),
+      oos = fs.create(new Path(s"$progressDirectoryPath/${PathTools.makeProgressFileName(commitTime)}"),
         true)
       offsetToCommit.foreach {
         case (namespace, ehNameAndPartitionToOffsetAndSeq) =>
@@ -309,8 +304,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
   private def createMetadata(fs: FileSystem, commitTime: Long): Boolean = {
     var oos: FSDataOutputStream = null
     try {
-      oos = fs.create(new Path(s"$progressMetadataDirStr/" +
-        s"${PathTools.progressMetadataNamePattern(commitTime)}"), true)
+      oos = fs.create(new Path(s"$metadataDirectoryStr/" + s"${PathTools.makeMetadataFileName(commitTime)}"), true)
       true
     } catch {
       case e: Exception =>
@@ -363,13 +357,12 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
   private def allProgressRecords(
       timestamp: Long,
       ehConnectors: List[EventHubsConnector]): List[Path] = {
-    val fs = progressTempDirectoryPath.getFileSystem(hadoopConfiguration)
+    val fs = tempDirectoryPath.getFileSystem(hadoopConfiguration)
     ehConnectors.flatMap { ehConnector =>
       ehConnector.connectedInstances.map(ehNameAndPartition =>
-        new Path(progressTempDirStr +
-          s"/${PathTools.progressTempFileNamePattern(ehConnector.streamId, ehConnector.uid,
-            ehNameAndPartition, timestamp)}"))
-    }.filter(fs.exists _)
+        PathTools.makeTempFilePath(
+          tempDirectoryStr, ehConnector.streamId, ehConnector.uid, ehNameAndPartition, timestamp))
+    }.filter(fs.exists)
   }
 
   /**
@@ -383,7 +376,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
     val records = new ListBuffer[ProgressRecord]
     val ret = new mutable.HashMap[String, Map[EventHubNameAndPartition, (Long, Long)]]
     try {
-      val fs = progressTempDirPath.getFileSystem(hadoopConfiguration)
+      val fs = tempDirectoryPath.getFileSystem(hadoopConfiguration)
       val files = allProgressRecords(timestamp, ehConnectors).iterator
       while (files.hasNext) {
         val file = files.next()
@@ -418,8 +411,8 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
   }
 
   def cleanProgressFile(timestampToClean: Long): Unit = {
-    val fs = progressDirPath.getFileSystem(hadoopConfiguration)
-    val allUselessFiles = fs.listStatus(progressDirPath, new PathFilter {
+    val fs = progressDirectoryPath.getFileSystem(hadoopConfiguration)
+    val allUselessFiles = fs.listStatus(progressDirectoryPath, new PathFilter {
       override def accept(path: Path): Boolean = fromPathToTimestamp(path) <= timestampToClean
     }).map(_.getPath)
     val sortedFileList = allUselessFiles.sortWith((p1, p2) => fromPathToTimestamp(p1) >
@@ -431,7 +424,7 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
       }
     }
     // clean temp directory
-    val allUselessTempFiles = fs.listStatus(progressTempDirPath, new PathFilter {
+    val allUselessTempFiles = fs.listStatus(tempDirectoryPath, new PathFilter {
       override def accept(path: Path): Boolean = fromPathToTimestamp(path) <= timestampToClean
     }).map(_.getPath)
     if (allUselessTempFiles.nonEmpty) {
@@ -445,9 +438,9 @@ private[spark] abstract class ProgressTrackerBase[T <: EventHubsConnector](
 
   private def scheduleMetadataCleanTask(): ScheduledFuture[_] = {
     val metadataCleanTask = new Runnable {
-      override def run() = {
-        val fs = progressMetadataDirectoryPath.getFileSystem(new Configuration())
-        val allMetadataFiles = fs.listStatus(progressMetadataDirPath)
+      override def run(): Unit = {
+        val fs = metadataDirectoryPath.getFileSystem(new Configuration())
+        val allMetadataFiles = fs.listStatus(metadataDirectoryPath)
         val sortedMetadataFiles = allMetadataFiles.sortWith((f1, f2) => f1.getPath.getName.toLong <
           f2.getPath.getName.toLong)
         sortedMetadataFiles.take(math.max(sortedMetadataFiles.length - 1, 0)).map{

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressTrackerBase.scala
@@ -47,10 +47,9 @@ abstract class ProgressTrackerBase[T <: EventHubsConnector](
 
   def eventHubNameAndPartitions: Map[String, List[EventHubNameAndPartition]]
 
-  /* Metadata is maintained for fast ProgressTracker initialization and can cleaned independently
-     from Spark checkpoint files. We'll clean metadata here to ensure it's cleaned whether or not
-     Spark checkpointing is enabled.
-   */
+  // Metadata is maintained for fast ProgressTracker initialization and can cleaned independently
+  // from Spark checkpoint files. We'll clean metadata here to ensure it's cleaned whether or not
+  // Spark checkpointing is enabled.
   private val threadPoolForMetadataClean = new ScheduledThreadPoolExecutor(1)
   protected val metadataCleanupFuture: ScheduledFuture[_] = scheduleMetadataCleanTask()
 

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressWriter.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressWriter.scala
@@ -34,14 +34,14 @@ private[spark] class ProgressWriter(
      progressDir: String,
      subDirIdentifiers: String*) extends Logging {
 
-  // TODO: Why can't we get this info from one of the ProgressTrackers? This info is available there.
-  // TODO: Come up with better name
+  // TODO: Why can't we get this info from one of the ProgressTrackers?
+  // TODO: Come up with better name for this guy
   private val tempProgressTrackingPointStr =
     PathTools.makeTempDirectoryStr(progressDir, subDirIdentifiers: _*) + "/" +
       PathTools.makeTempFileName(streamId, uid, eventHubNameAndPartition, timestamp)
 
-  // TODO: Why can't we get this info from one of the ProgressTrackers? This info is available there.
-  // TODO: Come up with better name
+  // TODO: Why can't we get this info from one of the ProgressTrackers?
+  // TODO: Come up with better name for this guy
   private[spark] val tempProgressTrackingPointPath = new Path(tempProgressTrackingPointStr)
 
   def write(recordTime: Long, cpOffset: Long, cpSeq: Long): Unit = {

--- a/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressWriter.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubscommon/progress/ProgressWriter.scala
@@ -34,10 +34,14 @@ private[spark] class ProgressWriter(
      progressDir: String,
      subDirIdentifiers: String*) extends Logging {
 
-  private val tempProgressTrackingPointStr = PathTools.progressTempFileStr(
-    PathTools.progressTempDirPathStr(progressDir, subDirIdentifiers: _*),
-    streamId, uid, eventHubNameAndPartition, timestamp)
+  // TODO: Why can't we get this info from one of the ProgressTrackers? This info is available there.
+  // TODO: Come up with better name
+  private val tempProgressTrackingPointStr =
+    PathTools.makeTempDirectoryStr(progressDir, subDirIdentifiers: _*) + "/" +
+      PathTools.makeTempFileName(streamId, uid, eventHubNameAndPartition, timestamp)
 
+  // TODO: Why can't we get this info from one of the ProgressTrackers? This info is available there.
+  // TODO: Come up with better name
   private[spark] val tempProgressTrackingPointPath = new Path(tempProgressTrackingPointStr)
 
   def write(recordTime: Long, cpOffset: Long, cpSeq: Long): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSource.scala
@@ -221,7 +221,7 @@ private[spark] class EventHubsSource(
   private def composeOffsetRange(endOffset: EventHubsBatchRecord): List[OffsetRange] = {
     val filterOffsetAndType = {
       if (committedOffsetsAndSeqNums.batchId == -1) {
-        val startSeqs = eventHubClient.startSeqOfPartition(false, connectedInstances)
+        val startSeqs = eventHubClient.startSeqOfPartition(retryIfFail = false, connectedInstances)
         require(startSeqs.isDefined, s"cannot fetch start seqs for eventhubs $eventHubsName")
         committedOffsetsAndSeqNums = EventHubsOffset(-1, committedOffsetsAndSeqNums.offsets.map {
           case (ehNameAndPartition, (offset, _)) =>

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
@@ -63,7 +63,6 @@ private[spark] class StructuredStreamingProgressTracker private[spark](
       val progressDirExist = fs.exists(progressDirectoryPath)
       if (progressDirExist) {
         val (validationPass, latestFile) = validateProgressFile(fs)
-        println(s"$latestFile")
         if (!validationPass) {
           if (latestFile.isDefined) {
             logWarning(s"latest progress file ${latestFile.get} corrupt, rebuild file...")

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
@@ -32,9 +32,12 @@ class StructuredStreamingProgressTracker private[spark](
     hadoopConfiguration: Configuration)
   extends ProgressTrackerBase(progressDir, appName, hadoopConfiguration) {
 
-  private[spark] override lazy val progressDirectoryStr = PathTools.makeProgressDirectoryStr(progressDir, appName, uid)
-  private[spark] override lazy val tempDirectoryStr = PathTools.makeTempDirectoryStr(progressDir, appName, uid)
-  private[spark] override lazy val metadataDirectoryStr = PathTools.makeMetadataDirectoryStr(progressDir, appName, uid)
+  private[spark] override lazy val progressDirectoryStr =
+    PathTools.makeProgressDirectoryStr(progressDir, appName, uid)
+  private[spark] override lazy val tempDirectoryStr =
+    PathTools.makeTempDirectoryStr(progressDir, appName, uid)
+  private[spark] override lazy val metadataDirectoryStr =
+    PathTools.makeMetadataDirectoryStr(progressDir, appName, uid)
 
   override def eventHubNameAndPartitions: Map[String, List[EventHubNameAndPartition]] = {
     val connector = StructuredStreamingProgressTracker.registeredConnectors(uid)

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
@@ -24,8 +24,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.eventhubscommon.{EventHubNameAndPartition, EventHubsConnector}
 import org.apache.spark.eventhubscommon.progress.{PathTools, ProgressTrackerBase}
 
-private[spark]
-class StructuredStreamingProgressTracker private[spark](
+private[spark] class StructuredStreamingProgressTracker private[spark](
     uid: String,
     progressDir: String,
     appName: String,

--- a/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTracker.scala
@@ -31,12 +31,12 @@ private[spark] class StructuredStreamingProgressTracker private[spark](
     hadoopConfiguration: Configuration)
   extends ProgressTrackerBase(progressDir, appName, hadoopConfiguration) {
 
-  private[spark] override lazy val progressDirectoryStr =
-    PathTools.makeProgressDirectoryStr(progressDir, appName, uid)
-  private[spark] override lazy val tempDirectoryStr =
-    PathTools.makeTempDirectoryStr(progressDir, appName, uid)
-  private[spark] override lazy val metadataDirectoryStr =
-    PathTools.makeMetadataDirectoryStr(progressDir, appName, uid)
+  private[spark] override lazy val progressDirectoryStr = PathTools.makeProgressDirectoryStr(
+    progressDir, appName, uid)
+  private[spark] override lazy val tempDirectoryStr = PathTools.makeTempDirectoryStr(progressDir,
+    appName, uid)
+  private[spark] override lazy val metadataDirectoryStr = PathTools.makeMetadataDirectoryStr(
+    progressDir, appName, uid)
 
   override def eventHubNameAndPartitions: Map[String, List[EventHubNameAndPartition]] = {
     val connector = StructuredStreamingProgressTracker.registeredConnectors(uid)

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -408,5 +408,5 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
 
 private[eventhubs] object EventHubDirectDStream {
   val cleanupLock = new Object
-  var lastCleanupTime = -1L
+  var lastCleanupTime: Long = -1L
 }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStream.scala
@@ -408,5 +408,5 @@ private[eventhubs] class EventHubDirectDStream private[eventhubs] (
 
 private[eventhubs] object EventHubDirectDStream {
   val cleanupLock = new Object
-  var lastCleanupTime: Long = -1L
+  var lastCleanupTime = -1L
 }

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
@@ -104,9 +104,9 @@ private[eventhubs] class EventHubsReceiver(
   private[eventhubs] class EventHubsMessageHandler() extends Runnable {
 
     // The checkpoint interval defaults to 10 seconds if not provided
-    val checkpointInterval: Long =
-      eventhubsParams.getOrElse("eventhubs.checkpoint.interval", "10").toLong * 1000
-    var nextCheckpointTime: Long = System.currentTimeMillis() + checkpointInterval
+    val checkpointInterval = eventhubsParams.getOrElse("eventhubs.checkpoint.interval", "10")
+      .toLong * 1000
+    var nextCheckpointTime = System.currentTimeMillis() + checkpointInterval
 
     def run() {
       logInfo("Begin EventHubsMessageHandler for partition " + partitionId)

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsReceiver.scala
@@ -36,7 +36,7 @@ private[eventhubs] class EventHubsReceiver(
     maximumEventRate: Int) extends Receiver[Array[Byte]](storageLevel) with Logging {
 
   // If offset store is empty we construct one using provided parameters
-  var myOffsetStore = offsetStore.getOrElse(new DfsBasedOffsetStore(
+  val myOffsetStore: OffsetStore = offsetStore.getOrElse(new DfsBasedOffsetStore(
     eventhubsParams("eventhubs.checkpoint.dir"),
     eventhubsParams("eventhubs.namespace"),
     eventhubsParams("eventhubs.name"),
@@ -90,7 +90,7 @@ private[eventhubs] class EventHubsReceiver(
   }
 
   def processReceivedMessagesInBatch(eventDataBatch: Iterable[EventData]): Unit = {
-    store(eventDataBatch.map(x => x.getBody).toIterator)
+    store(eventDataBatch.map(x => x.getBytes).toIterator)
     val maximumSequenceNumber: Long = eventDataBatch.map(x =>
       x.getSystemProperties.getSequenceNumber).reduceLeft { (x, y) => if (x > y) x else y }
 
@@ -104,9 +104,9 @@ private[eventhubs] class EventHubsReceiver(
   private[eventhubs] class EventHubsMessageHandler() extends Runnable {
 
     // The checkpoint interval defaults to 10 seconds if not provided
-    val checkpointInterval = eventhubsParams.getOrElse("eventhubs.checkpoint.interval", "10").
-      toInt * 1000
-    var nextCheckpointTime = System.currentTimeMillis() + checkpointInterval
+    val checkpointInterval: Long =
+      eventhubsParams.getOrElse("eventhubs.checkpoint.interval", "10").toLong * 1000
+    var nextCheckpointTime: Long = System.currentTimeMillis() + checkpointInterval
 
     def run() {
       logInfo("Begin EventHubsMessageHandler for partition " + partitionId)
@@ -118,7 +118,7 @@ private[eventhubs] class EventHubsReceiver(
         try {
           val receivedEvents = receiverClient.receive()
           if (receivedEvents != null && receivedEvents.nonEmpty) {
-            val eventCount = receivedEvents.count(x => x.getBodyLength > 0)
+            val eventCount = receivedEvents.count(x => x.getBytes.length > 0)
             val sequenceNumbers = receivedEvents.map(x =>
               x.getSystemProperties.getSequenceNumber)
             if (sequenceNumbers != null && sequenceNumbers.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/EventHubsUtils.scala
@@ -150,7 +150,7 @@ object EventHubsUtils {
       receiverClient: EventHubsClientWrapper): Receiver[Array[Byte]] = {
     val maximumEventRate = streamingContext.conf.getInt("spark.streaming.receiver.maxRate", 0)
     val walEnabled = streamingContext.conf.getBoolean(
-      "spark.streaming.receiver.writeAheadLog.enable", false)
+      "spark.streaming.receiver.writeAheadLog.enable", defaultValue = false)
 
     if (walEnabled) {
       new ReliableEventHubsReceiver(eventhubsParams, partitionId, storageLevel, offsetStore,

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/ReliableEventHubsReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/ReliableEventHubsReceiver.scala
@@ -79,7 +79,7 @@ class ReliableEventHubsReceiver(
      * It is guaranteed by Eventhubs that the event data with the highest sequence number has the
      * largest offset
      */
-    blockGenerator.addMultipleDataWithCallback(eventDataBatch.map(x => x.getBody).toIterator,
+    blockGenerator.addMultipleDataWithCallback(eventDataBatch.map(x => x.getBytes).toIterator,
       offsetMetadata)
   }
 

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DfsBasedOffsetStore.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DfsBasedOffsetStore.scala
@@ -19,9 +19,8 @@ package org.apache.spark.streaming.eventhubs.checkpoint
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.SparkContext
-
+import org.apache.spark.internal.Logging
 
 /**
  * A DFS based OffsetStore implementation

--- a/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DirectDStreamProgressTracker.scala
+++ b/core/src/main/scala/org/apache/spark/streaming/eventhubs/checkpoint/DirectDStreamProgressTracker.scala
@@ -36,8 +36,7 @@ import org.apache.spark.eventhubscommon.progress.ProgressTrackerBase
  * @param appName the name of Spark application
  * @param hadoopConfiguration the hadoop configuration instance
  */
-private[spark]
-class DirectDStreamProgressTracker private[spark](
+private[spark] class DirectDStreamProgressTracker private[spark](
     progressDir: String,
     appName: String,
     hadoopConfiguration: Configuration)

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/EventhubsImplicitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/EventhubsImplicitsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.streaming.{StreamingContext, TestSuiteBase}
 class EventhubsImplicitsSuite
   extends TestSuiteBase with org.scalatest.Matchers with MockitoSugar {
 
-  val ehParams: Map[String, String] = Map(
+  val ehParams = Map(
     "eventhubs.policyname" -> "policyname",
     "eventhubs.policykey" -> "policykey",
     "eventhubs.namespace" -> "namespace",

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/EventhubsImplicitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/EventhubsImplicitsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.streaming.{StreamingContext, TestSuiteBase}
 class EventhubsImplicitsSuite
   extends TestSuiteBase with org.scalatest.Matchers with MockitoSugar {
 
-  val ehParams = Map[String, String] (
+  val ehParams: Map[String, String] = Map(
     "eventhubs.policyname" -> "policyname",
     "eventhubs.policykey" -> "policykey",
     "eventhubs.namespace" -> "namespace",

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/client/EventHubsClientWrapperSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.streaming.eventhubs.checkpoint.OffsetStore
 class EventHubsClientWrapperSuite extends FunSuite with BeforeAndAfter with MockitoSugar {
   var ehClientWrapperMock: EventHubsClientWrapper = _
   var offsetStoreMock: OffsetStore = _
-  val ehParams = Map[String, String] (
+  val ehParams: Map[String, String] = Map(
     "eventhubs.policyname" -> "policyname",
     "eventhubs.policykey" -> "policykey",
     "eventhubs.namespace" -> "namespace",

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
@@ -80,7 +80,7 @@ class TestEventHubsReceiver(
     offsetType: EventHubsOffsetType)
   extends EventHubsClientWrapper {
 
-  val eventHubName: String = eventHubParameters("eventhubs.name")
+  val eventHubName = eventHubParameters("eventhubs.name")
 
   override def receive(expectedEventNum: Int): Iterable[EventData] = {
     val eventHubName = eventHubParameters("eventhubs.name")
@@ -233,7 +233,7 @@ class FragileEventHubClient private extends EventHubClient {
 // ugly stuff to make things checkpointable in tests
 object FragileEventHubClient {
 
-  var callIndex: Int = -1
+  var callIndex = -1
   var numBatchesBeforeCrashedEndpoint = 0
   var lastBatchWhenEndpointCrashed = 0
   var latestRecords: Map[EventHubNameAndPartition, (Long, Long)] = Map()

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable.ListBuffer
 
 import com.microsoft.azure.eventhubs.EventData
 
-import org.apache.spark.eventhubscommon.client.{EventHubClient, EventHubsClientWrapper, EventHubsOffsetTypes}
 import org.apache.spark.eventhubscommon.EventHubNameAndPartition
+import org.apache.spark.eventhubscommon.client.{EventHubClient, EventHubsClientWrapper, EventHubsOffsetTypes}
 import org.apache.spark.eventhubscommon.client.EventHubsOffsetTypes.EventHubsOffsetType
 import org.apache.spark.streaming.StreamingContext
 

--- a/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubscommon/utils/SimulatedEventHubs.scala
@@ -80,7 +80,7 @@ class TestEventHubsReceiver(
     offsetType: EventHubsOffsetType)
   extends EventHubsClientWrapper {
 
-  val eventHubName = eventHubParameters("eventhubs.name")
+  val eventHubName: String = eventHubParameters("eventhubs.name")
 
   override def receive(expectedEventNum: Int): Iterable[EventData] = {
     val eventHubName = eventHubParameters("eventhubs.name")
@@ -233,7 +233,7 @@ class FragileEventHubClient private extends EventHubClient {
 // ugly stuff to make things checkpointable in tests
 object FragileEventHubClient {
 
-  var callIndex = -1
+  var callIndex: Int = -1
   var numBatchesBeforeCrashedEndpoint = 0
   var lastBatchWhenEndpointCrashed = 0
   var latestRecords: Map[EventHubNameAndPartition, (Long, Long)] = Map()

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -536,7 +536,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest {
     val clockMove = Array.fill(9)(AdvanceManualClock(10)).toSeq
     val secondBatch = Seq(
       CheckAnswer(1 to 600: _*),
-      StopStream(recoverStreamId = true, commitPartialOffset = true),
+      StopStream(recoverStreamId = true, commitPartialOffset = true, partialType = "delete"),
       StartStream(trigger = ProcessingTime(10), triggerClock = manualClock,
         additionalConfs = Map("eventhubs.test.newSink" -> "true")),
       AddEventHubsData(eventHubsParameters, 17, eventPayloadsAndProperties.takeRight(400)))

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsSourceSuite.scala
@@ -357,8 +357,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest {
     dataSource.map(x => x.toInt + 1)
   }
 
-  test("Verify input row metric is correct when source" +
-    " is started with initial data") {
+  test("Verify input row metric is correct when source is started with initial data") {
     import testImplicits._
     val eventHubsParameters = buildEventHubsParamters("ns1", "eh1", 2, 3)
     val eventPayloadsAndProperties = generateIntKeyedData(6)
@@ -537,7 +536,7 @@ class EventHubsSourceSuite extends EventHubsStreamTest {
     val clockMove = Array.fill(9)(AdvanceManualClock(10)).toSeq
     val secondBatch = Seq(
       CheckAnswer(1 to 600: _*),
-      StopStream(recoverStreamId = true, commitPartialOffset = true, partialType = "delete"),
+      StopStream(recoverStreamId = true, commitPartialOffset = true),
       StartStream(trigger = ProcessingTime(10), triggerClock = manualClock,
         additionalConfs = Map("eventhubs.test.newSink" -> "true")),
       AddEventHubsData(eventHubsParameters, 17, eventPayloadsAndProperties.takeRight(400)))

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -93,7 +93,7 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
   }
 
   /** How long to wait for an active stream to catch up when checking a result. */
-  val streamingTimeout = 60.seconds
+  val streamingTimeout: Span = 60.seconds
 
 
   /** A trait for actions that can be performed while testing a streaming DataFrame. */
@@ -131,7 +131,8 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
         isSorted = false)
     }
 
-    def apply(rows: Row*): CheckAnswerRows = CheckAnswerRows(rows, false, false)
+    def apply(rows: Row*): CheckAnswerRows =
+      CheckAnswerRows(rows, lastOnly = false, isSorted = false)
 
     def apply[A : Encoder](partial: Boolean, lastOnly: Boolean, rows: A*): CheckAnswerRows = {
       val encoder = encoderFor[A]
@@ -279,7 +280,7 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
       }
     }
 
-    def isStreamWaitingAt(time: Long): Boolean = synchronized {waitStartTime == Some(time)}
+    def isStreamWaitingAt(time: Long): Boolean = synchronized {waitStartTime.contains(time)}
   }
 
 
@@ -413,7 +414,7 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
         timestamp: Long,
         brokenType: String): Unit = {
       val progressDir = progressTracker.progressDirectoryPath.toString
-      val metadataDir = progressTracker.progressMetadataDirectoryPath.toString
+      val metadataDir = progressTracker.metadataDirectoryPath.toString
       val progressFilePath = new Path(s"$progressDir/progress-$timestamp")
       val metadataFilePath = new Path(s"$metadataDir/$timestamp")
       val fs = progressFilePath.getFileSystem(new Configuration())
@@ -446,8 +447,10 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
             verify(triggerClock.isInstanceOf[SystemClock]
               || triggerClock.isInstanceOf[StreamManualClock],
               "Use either SystemClock or StreamManualClock to start the stream")
-            if (triggerClock.isInstanceOf[StreamManualClock]) {
-              manualClockExpectedTime = triggerClock.asInstanceOf[StreamManualClock].getTimeMillis()
+
+            triggerClock match {
+              case triggerClock: StreamManualClock =>
+                manualClockExpectedTime = triggerClock.getTimeMillis()
             }
 
             additionalConfs.foreach(pair => {

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -93,7 +93,7 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
   }
 
   /** How long to wait for an active stream to catch up when checking a result. */
-  val streamingTimeout: Span = 60.seconds
+  val streamingTimeout = 60 seconds
 
 
   /** A trait for actions that can be performed while testing a streaming DataFrame. */
@@ -280,7 +280,7 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
       }
     }
 
-    def isStreamWaitingAt(time: Long): Boolean = synchronized {waitStartTime.contains(time)}
+    def isStreamWaitingAt(time: Long): Boolean = synchronized {waitStartTime contains time}
   }
 
 

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/EventHubsStreamTest.scala
@@ -447,10 +447,8 @@ trait EventHubsStreamTest extends QueryTest with BeforeAndAfter
             verify(triggerClock.isInstanceOf[SystemClock]
               || triggerClock.isInstanceOf[StreamManualClock],
               "Use either SystemClock or StreamManualClock to start the stream")
-
-            triggerClock match {
-              case triggerClock: StreamManualClock =>
-                manualClockExpectedTime = triggerClock.getTimeMillis()
+            if (triggerClock.isInstanceOf[StreamManualClock]) {
+              manualClockExpectedTime = triggerClock.asInstanceOf[StreamManualClock].getTimeMillis()
             }
 
             additionalConfs.foreach(pair => {

--- a/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/streaming/eventhubs/checkpoint/StructuredStreamingProgressTrackerSuite.scala
@@ -37,26 +37,28 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
   }
 
   test("progress directory is created properly when it exists") {
-    fileSystem.mkdirs(new Path(PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName)))
+    fileSystem.mkdirs(PathTools.makeTempDirectoryPath(progressRootPath.toString, appName))
+
     progressTracker = StructuredStreamingProgressTracker
       .initInstance(eventhubsSource1.uid, progressRootPath.toString, appName, new Configuration())
+
     assert(fileSystem.exists(progressTracker.progressDirectoryPath))
   }
 
   test("temp progress is not cleaned up when partial temp progress exists") {
+    val tempPath = PathTools.makeTempDirectoryPath(progressRootPath.toString, appName)
 
-    val tempPath = new Path(PathTools.progressTempDirPathStr(progressRootPath.toString, appName))
     fileSystem.mkdirs(tempPath)
 
     val streamId = EventHubsSource.streamIdGenerator.get()
+    var tempFilePath = PathTools.makeTempFilePath(tempPath.toString,
+      streamId, eventhubsSource1.uid, eventhubsNamedPartitions("ns1").head, unixTimestamp)
 
-    var tempFilePath = new Path(PathTools.progressTempFileStr(tempPath.toString,
-      streamId, eventhubsSource1.uid, eventhubsNamedPartitions("ns1").head, unixTimestamp))
     fileSystem.create(tempFilePath)
 
-    tempFilePath = new Path(PathTools.progressTempFileStr(tempPath.toString,
-      streamId, eventhubsSource1.uid, eventhubsNamedPartitions("ns1").tail.head, unixTimestamp))
+    tempFilePath = PathTools.makeTempFilePath(tempPath.toString, streamId,
+      eventhubsSource1.uid, eventhubsNamedPartitions("ns1").tail.head, unixTimestamp)
+
     fileSystem.create(tempFilePath)
 
     val filesBefore = fileSystem.listStatus(tempPath)
@@ -67,11 +69,9 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
 
     val filesAfter = fileSystem.listStatus(tempPath)
     assert(filesAfter.size === 2)
-
   }
 
   test("incomplete progress will not be discarded") {
-
     // Register two eventhubs connectors to structured streaming progress tracker
 
     StructuredStreamingProgressTracker.registeredConnectors +=
@@ -97,7 +97,7 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
 
     // Progress records of all partitions of eventhubsSource2 are not updated
 
-    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get();
+    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get()
 
     progressWriter = new ProgressWriter(eventHubsSourceStreamId2,
       eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp,
@@ -116,31 +116,26 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
     StructuredStreamingProgressTracker.initInstance(eventhubsSource2.uid,
       progressRootPath.toString, appName, new Configuration())
 
-    var progressTempPath = PathTools.progressTempDirPathStr(progressRootPath.toString,
+    var progressTempPath = PathTools.makeTempDirectoryStr(progressRootPath.toString,
       appName, eventhubsSource1.uid)
 
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId1, eventhubsSource1.uid, eventhubsSource1.connectedInstances.head,
-      unixTimestamp))))
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId1, eventhubsSource1.uid, eventhubsSource1.connectedInstances(1),
-      unixTimestamp))))
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId1,
+      eventhubsSource1.uid, eventhubsSource1.connectedInstances.head, unixTimestamp)))
 
-    progressTempPath = PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName, eventhubsSource2.uid)
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId1,
+      eventhubsSource1.uid, eventhubsSource1.connectedInstances(1), unixTimestamp)))
 
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances.head,
-      unixTimestamp))))
+    progressTempPath = PathTools.makeTempDirectoryStr(
+      progressRootPath.toString, appName, eventhubsSource2.uid)
 
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances(1),
-      unixTimestamp))))
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp)))
 
-    assert(!fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances(2),
-      unixTimestamp))))
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances(1), unixTimestamp)))
 
+    assert(!fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances(2), unixTimestamp)))
   }
 
   test("start from the beginning of the streams when the latest progress file does not exist") {
@@ -172,7 +167,6 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
   }
 
   test("progress tracker can read back last progress correctly") {
-
     // Register two eventhubs connectors to structured streaming progress tracker
 
     StructuredStreamingProgressTracker.registeredConnectors +=
@@ -196,7 +190,7 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
 
     // Progress records of all partitions of eventhubsSource2 are updated
 
-    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get();
+    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get()
 
     progressWriter = new ProgressWriter(eventHubsSourceStreamId2,
       eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp,
@@ -238,7 +232,6 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
   }
 
   test("inconsistent timestamp in the progress tracks can be detected") {
-
     // Register two eventhubs connectors to structured streaming progress tracker
 
     StructuredStreamingProgressTracker.registeredConnectors +=
@@ -262,7 +255,7 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
 
     // Progress records of all partitions of eventhubsSource2 are not updated
 
-    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get();
+    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get()
 
     progressWriter = new ProgressWriter(eventHubsSourceStreamId2,
       eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp,
@@ -294,7 +287,6 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
   }
 
   test("latest offsets can be committed correctly and temp directory is not cleaned") {
-
     // Register two eventhubs connectors to structured streaming progress tracker
 
     StructuredStreamingProgressTracker.registeredConnectors +=
@@ -318,7 +310,7 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
 
     // Progress records of all partitions of eventhubsSource2 are not updated
 
-    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get();
+    val eventHubsSourceStreamId2 = EventHubsSource.streamIdGenerator.get()
 
     progressWriter = new ProgressWriter(eventHubsSourceStreamId2,
       eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp,
@@ -346,32 +338,29 @@ class StructuredStreamingProgressTrackerSuite extends SharedSQLContext {
     progressTracker2.commit(progressTracker2.collectProgressRecordsForBatch(
       unixTimestamp, List(eventhubsSource2)), unixTimestamp)
 
-    var progressTempPath = PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName, eventhubsSource1.uid)
+    var progressTempPath = PathTools.makeTempDirectoryStr(
+      progressRootPath.toString, appName, eventhubsSource1.uid)
 
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId1, eventhubsSource1.uid, eventhubsSource1.connectedInstances.head,
-      unixTimestamp))))
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId1, eventhubsSource1.uid, eventhubsSource1.connectedInstances(1),
-      unixTimestamp))))
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId1,
+      eventhubsSource1.uid, eventhubsSource1.connectedInstances.head, unixTimestamp)))
 
-    progressTempPath = PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName, eventhubsSource2.uid)
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId1,
+      eventhubsSource1.uid, eventhubsSource1.connectedInstances(1), unixTimestamp)))
 
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances.head,
-      unixTimestamp))))
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances(1),
-      unixTimestamp))))
-    assert(fileSystem.exists(new Path(PathTools.progressTempFileStr(progressTempPath,
-      eventHubsSourceStreamId2, eventhubsSource2.uid, eventhubsSource2.connectedInstances(2),
-      unixTimestamp))))
+    progressTempPath = PathTools.makeTempDirectoryStr(
+      progressRootPath.toString, appName, eventhubsSource2.uid)
+
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances.head, unixTimestamp)))
+
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances(1), unixTimestamp)))
+
+    assert(fileSystem.exists(PathTools.makeTempFilePath(progressTempPath, eventHubsSourceStreamId2,
+      eventhubsSource2.uid, eventhubsSource2.connectedInstances(2), unixTimestamp)))
   }
 
   test("locate progress file correctly based on timestamp") {
-
     // Register one eventhubs connector to structured streaming progress tracker
 
     StructuredStreamingProgressTracker.registeredConnectors +=

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/CheckpointAndProgressTrackerTestSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/CheckpointAndProgressTrackerTestSuiteBase.scala
@@ -38,7 +38,7 @@ trait CheckpointAndProgressTrackerTestSuiteBase extends EventHubTestSuiteBase { 
   protected def createContextForCheckpointOperation(
       batchDuration: Duration, checkpointDirectory: String): StreamingContext = {
     val conf = new SparkConf().setMaster("local[*]").setAppName(appName)
-    conf.set("spark.streaming.clock", classOf[ManualClock].getName())
+    conf.set("spark.streaming.clock", classOf[ManualClock].getName)
     val ssc = new StreamingContext(SparkContext.getOrCreate(conf), batchDuration)
     ssc.checkpoint(checkpointDirectory)
     ssc

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/EventHubDirectDStreamSuite.scala
@@ -31,7 +31,7 @@ class EventHubDirectDStreamSuite extends EventHubTestSuiteBase with MockitoSugar
 
   override def batchDuration: Duration = Seconds(1)
 
-  val eventhubParameters = Map[String, String] (
+  val eventhubParameters: Map[String, String] = Map(
     "eventhubs.policyname" -> "policyName",
     "eventhubs.policykey" -> "policykey",
     "eventhubs.namespace" -> "eventhubs",

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ProgressTrackingAndCheckpointSuite.scala
@@ -283,7 +283,7 @@ class ProgressTrackingAndCheckpointSuite extends CheckpointAndProgressTrackerTes
         inputDStream.map(eventData => eventData.getProperties.get("output").asInstanceOf[Int] + 1),
       expectedOutputBeforeRestart,
       expectedOutputAfterRestart,
-      directoryToClean = Some(progressTracker.progressMetadataDirectoryPath))
+      directoryToClean = Some(progressTracker.metadataDirectoryPath))
   }
 
 

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/ReliableEventHubsReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/ReliableEventHubsReceiverSuite.scala
@@ -47,7 +47,7 @@ class ReliableEventHubsReceiverSuite extends FunSuite with BeforeAndAfter with B
   private var streamingContext: StreamingContext = _
   private var ehClientWrapperMock: EventHubsClientWrapper = _
   private var offsetStoreMock: OffsetStore = _
-  private var tempDirectory: File = null
+  private var tempDirectory: File = _
 
   private val eventhubParameters = Map[String, String] (
     "eventhubs.policyname" -> "policyname",
@@ -147,10 +147,10 @@ class ReliableEventHubsReceiverSuite extends FunSuite with BeforeAndAfter with B
 class MyMockedEventHubsClientWrapper(
     emitCount: Int,
     exceptionCount: Int) extends EventHubsClientWrapper with MockitoSugar {
-  var offset = -1
+  var offset: Int = -1
   var count = 0
   var partition = "0"
-  var myExceptionCount = exceptionCount
+  var myExceptionCount: Int = exceptionCount
 
   override def createReceiverInternal(
       connectionString: String,

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
@@ -155,13 +155,13 @@ class ProgressTrackerSuite extends SharedUtils {
     val dStream =
       createDirectStreams(ssc, "namespace1", progressRootPath.toString,
         Map("eh1" -> Map("eventhubs.partition.count" -> "1"),
-            "eh2" -> Map("eventhubs.partition.count" -> "2"),
-            "eh3" -> Map("eventhubs.partition.count" -> "3")))
+          "eh2" -> Map("eventhubs.partition.count" -> "2"),
+          "eh3" -> Map("eventhubs.partition.count" -> "3")))
     val dStream1 =
       createDirectStreams(ssc, "namespace2", progressRootPath.toString,
         Map("eh11" -> Map("eventhubs.partition.count" -> "1"),
-            "eh12" -> Map("eventhubs.partition.count" -> "2"),
-            "eh13" -> Map("eventhubs.partition.count" -> "3")))
+          "eh12" -> Map("eventhubs.partition.count" -> "2"),
+          "eh13" -> Map("eventhubs.partition.count" -> "3")))
     dStream.start()
     dStream1.start()
 

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
@@ -167,7 +167,6 @@ class ProgressTrackerSuite extends SharedUtils {
 
     val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-
     progressTracker = DirectDStreamProgressTracker
       .initInstance(progressRootPath.toString, appName, new Configuration())
 
@@ -242,19 +241,15 @@ class ProgressTrackerSuite extends SharedUtils {
     var progressWriter = new ProgressWriter(0, "namespace1", eh1Partition0,
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
-
     progressWriter = new ProgressWriter(0, "namespace1", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
-
     progressWriter = new ProgressWriter(0, "namespace2", eh1Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 10, 20)
-
     progressWriter = new ProgressWriter(0, "namespace2", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 20, 30)
-
     val s = progressTracker.asInstanceOf[DirectDStreamProgressTracker]
       .collectProgressRecordsForBatch(1000L, List(connector1, connector2))
 
@@ -279,15 +274,12 @@ class ProgressTrackerSuite extends SharedUtils {
     var progressWriter = new ProgressWriter(0, "namespace1", eh1Partition0,
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
-
     progressWriter = new ProgressWriter(0, "namespace1", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
-
     progressWriter = new ProgressWriter(0, "namespace2", eh1Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(2000L, 10, 20)
-
     progressWriter = new ProgressWriter(0, "namespace2", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 20, 30)
@@ -305,15 +297,12 @@ class ProgressTrackerSuite extends SharedUtils {
     var progressWriter = new ProgressWriter(0, "namespace1", EventHubNameAndPartition("eh1", 0),
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 0)
-
     progressWriter = new ProgressWriter(0, "namespace1", EventHubNameAndPartition("eh2", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 1, 1)
-
     progressWriter = new ProgressWriter(0, "namespace2", EventHubNameAndPartition("eh1", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 2, 2)
-
     progressWriter = new ProgressWriter(0, "namespace2", EventHubNameAndPartition("eh2", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 3, 3)
@@ -326,17 +315,13 @@ class ProgressTrackerSuite extends SharedUtils {
         EventHubNameAndPartition("eh1", 3) -> (2L, 2L),
         EventHubNameAndPartition("eh2", 4) -> (3L, 3L)))
     progressTracker.asInstanceOf[DirectDStreamProgressTracker].commit(offsetToCommit, 1000L)
-
-    val namespace1Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
-      read("namespace1", 1000L, fallBack = false)
-
+    val namespace1Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+      .read("namespace1", 1000L, fallBack = false)
     assert(namespace1Offsets === OffsetRecord(1000L, Map(
       EventHubNameAndPartition("eh1", 0) -> (0L, 0L),
       EventHubNameAndPartition("eh2", 1) -> (1L, 1L))))
-
-    val namespace2Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
-      read("namespace2", 1000L, fallBack = false)
-
+    val namespace2Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+      .read("namespace2", 1000L, fallBack = false)
     assert(namespace2Offsets === OffsetRecord(1000L, Map(
       EventHubNameAndPartition("eh1", 3) -> (2L, 2L),
       EventHubNameAndPartition("eh2", 4) -> (3L, 3L))))
@@ -413,12 +398,9 @@ class ProgressTrackerSuite extends SharedUtils {
 
     val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-
     writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
-
     val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
     createMetadataFile(fs, metadataPath, 1000L)
-
     val result = progressTracker.read("namespace1", 1000, fallBack = true)
 
     assert(result.timestamp == 1000L)
@@ -431,15 +413,11 @@ class ProgressTrackerSuite extends SharedUtils {
 
     val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-
     writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
     writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 0, 1)
-
     val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
-
     createMetadataFile(fs, metadataPath, 1000L)
     createMetadataFile(fs, metadataPath, 2000L)
-
     val (sourceOfLatestFile, result) = progressTracker.getLatestFile(fs)
 
     assert(sourceOfLatestFile === 0)
@@ -455,10 +433,8 @@ class ProgressTrackerSuite extends SharedUtils {
 
     writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
     writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 0, 1)
-
     val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
     createMetadataFile(fs, metadataPath, 1000L)
-
     val (sourceOfLatestFile, result) = progressTracker.getLatestFile(fs)
 
     assert(sourceOfLatestFile === 0)

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
@@ -32,18 +32,11 @@ class ProgressTrackerSuite extends SharedUtils {
       sId: Int,
       uniqueId: String,
       connedInstances: List[EventHubNameAndPartition]) extends EventHubsConnector {
+    override def streamId: Int = sId
 
-    override def streamId: Int = {
-      sId
-    }
+    override def uid: String = uniqueId
 
-    override def uid: String = {
-      uniqueId
-    }
-
-    override def connectedInstances: List[EventHubNameAndPartition] = {
-      connedInstances
-    }
+    override def connectedInstances: List[EventHubNameAndPartition] = connedInstances
   }
 
   override def beforeEach(): Unit = {
@@ -62,99 +55,91 @@ class ProgressTrackerSuite extends SharedUtils {
       offset: Int,
       seq: Int): Unit = {
     for (partitionId <- partitionRange) {
-      Files.write(
-        Paths.get(progressPath + s"/${PathTools.progressFileNamePattern(timestamp)}"),
-        (ProgressRecord(timestamp, namespace, ehName, partitionId, offset,
-          seq).toString + "\n").getBytes, {
-          if (Files.exists(Paths.get(progressPath +
-            s"/${PathTools.progressFileNamePattern(timestamp)}"))) {
-            StandardOpenOption.APPEND
-          } else {
-            StandardOpenOption.CREATE
-          }
-        })
+      val filePath = Paths.get(progressPath + s"/${PathTools.makeProgressFileName(timestamp)}")
+      val stdOpenOption = if (Files.exists(filePath))
+        StandardOpenOption.APPEND
+      else StandardOpenOption.CREATE
+
+      Files.write(filePath,
+        s"${ProgressRecord(timestamp, namespace, ehName, partitionId, offset, seq)
+          .toString}\n".getBytes,
+        stdOpenOption)
     }
   }
 
-  private def createMetadataFile(fs: FileSystem, metadataPath: String, timestamp: Long): Unit = {
-    fs.create(new Path(s"$metadataPath/${PathTools.progressMetadataNamePattern(timestamp)}"))
-  }
+  private def createMetadataFile(fs: FileSystem, metadataPath: String, timestamp: Long): Unit =
+    fs.create(new Path(s"$metadataPath/${PathTools.makeMetadataFileName(timestamp)}"))
 
   test("progress temp directory is created properly when progress and progress temp" +
     " directory do not exist") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
     assert(fs.exists(progressTracker.progressDirectoryPath))
-    assert(fs.exists(progressTracker.progressTempDirectoryPath))
+    assert(fs.exists(progressTracker.tempDirectoryPath))
   }
 
   test("progress temp directory is created properly when progress exists while progress" +
     " temp does not") {
-    fs.mkdirs(new Path(PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName)))
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    fs.mkdirs(PathTools.makeTempDirectoryPath(progressRootPath.toString, appName))
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
     assert(fs.exists(progressTracker.progressDirectoryPath))
-    assert(fs.exists(progressTracker.progressTempDirectoryPath))
+    assert(fs.exists(progressTracker.tempDirectoryPath))
   }
 
   test("temp progress is cleaned up when a potentially partial temp progress exists") {
-    val tempPath = new Path(PathTools.progressTempDirPathStr(progressRootPath.toString +
-      "/progress", appName))
+    val tempPath = PathTools.makeTempDirectoryPath(progressRootPath.toString + "/progress", appName)
     fs.mkdirs(tempPath)
     fs.create(new Path(tempPath.toString + "/temp_file"))
     val filesBefore = fs.listStatus(tempPath)
     assert(filesBefore.size === 1)
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
-    assert(fs.exists(progressTracker.progressTempDirectoryPath))
-    val filesAfter = fs.listStatus(progressTracker.progressTempDirectoryPath)
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+    assert(fs.exists(progressTracker.tempDirectoryPath))
+    val filesAfter = fs.listStatus(progressTracker.tempDirectoryPath)
     assert(filesAfter.size === 0)
   }
 
   test("incomplete progress would be discarded") {
     createDirectStreams(ssc, "namespace1", progressRootPath.toString,
       Map("eh1" -> Map("eventhubs.partition.count" -> "1"),
-        "eh2" -> Map("eventhubs.partition.count" -> "2"),
-        "eh3" -> Map("eventhubs.partition.count" -> "3")))
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+          "eh2" -> Map("eventhubs.partition.count" -> "2"),
+          "eh3" -> Map("eventhubs.partition.count" -> "3")))
+
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1",
-      "eh1", 0 to 0, 0, 0)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1",
-      "eh2", 0 to 1, 0, 0)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1",
-      "eh3", 0 to 2, 0, 0)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1",
-      "eh1", 0 to 0, 1, 1)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1",
-      "eh2", 0 to 1, 1, 1)
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
-    assert(!fs.exists(new Path(progressPath.toString + "/progress-2000")))
-    assert(fs.exists(new Path(progressPath.toString + "/progress-1000")))
+
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 0)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2", 0 to 1, 0, 0)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3", 0 to 2, 0, 0)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 1, 1)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh2", 0 to 1, 1, 1)
+
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+    assert(!fs.exists(new Path(progressPath + "/progress-2000")))
+    assert(fs.exists(new Path(progressPath + "/progress-1000")))
   }
 
   test("health progress file is kept") {
     // create direct streams, generate 6 EventHubAndPartitions
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 0)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2",
-      0 to 1, 0, 0)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3",
-      0 to 2, 0, 0)
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
-    assert(fs.exists(new Path(progressPath.toString + "/progress-1000")))
+
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 0)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2", 0 to 1, 0, 0)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3", 0 to 2, 0, 0)
+
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+    assert(fs.exists(new Path(progressPath + "/progress-1000")))
   }
 
   private def verifyProgressFile(
       namespace: String, ehName: String, partitionRange: Range,
       timestamp: Long, expectedOffsetAndSeq: Seq[(Long, Long)]): Unit = {
-    val ehMap = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
-      read(namespace, timestamp - 1000L, fallBack = false)
+    val ehMap = progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+      .read(namespace, timestamp - 1000L, fallBack = false)
     var expectedOffsetAndSeqIdx = 0
     for (partitionId <- partitionRange) {
       assert(ehMap.offsets(EventHubNameAndPartition(ehName, partitionId)) ===
@@ -168,19 +153,22 @@ class ProgressTrackerSuite extends SharedUtils {
     val dStream =
       createDirectStreams(ssc, "namespace1", progressRootPath.toString,
         Map("eh1" -> Map("eventhubs.partition.count" -> "1"),
-          "eh2" -> Map("eventhubs.partition.count" -> "2"),
-          "eh3" -> Map("eventhubs.partition.count" -> "3")))
+            "eh2" -> Map("eventhubs.partition.count" -> "2"),
+            "eh3" -> Map("eventhubs.partition.count" -> "3")))
     val dStream1 =
       createDirectStreams(ssc, "namespace2", progressRootPath.toString,
         Map("eh11" -> Map("eventhubs.partition.count" -> "1"),
-          "eh12" -> Map("eventhubs.partition.count" -> "2"),
-          "eh13" -> Map("eventhubs.partition.count" -> "3")))
+            "eh12" -> Map("eventhubs.partition.count" -> "2"),
+            "eh13" -> Map("eventhubs.partition.count" -> "3")))
     dStream.start()
     dStream1.start()
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+
     verifyProgressFile("namespace1", "eh1", 0 to 0, 1000L, Seq((-1L, -1L)))
     verifyProgressFile("namespace1", "eh2", 0 to 1, 1000L, Seq((-1L, -1L), (-1L, -1L)))
     verifyProgressFile("namespace1", "eh3", 0 to 2, 1000L, Seq((-1L, -1L), (-1L, -1L), (-1L, -1L)))
@@ -191,23 +179,18 @@ class ProgressTrackerSuite extends SharedUtils {
 
   test("the progress tracks can be read correctly") {
     // generate 6 EventHubAndPartitions
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2",
-      0 to 1, 0, 2)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3",
-      0 to 2, 0, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11",
-      0 to 0, 1, 2)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12",
-      0 to 1, 2, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13",
-      0 to 2, 3, 4)
 
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2", 0 to 1, 0, 2)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3", 0 to 2, 0, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11", 0 to 0, 1, 2)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12", 0 to 1, 2, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13", 0 to 2, 3, 4)
+
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
 
     verifyProgressFile("namespace1", "eh1", 0 to 0, 2000L, Seq((0, 1)))
     verifyProgressFile("namespace1", "eh2", 0 to 1, 2000L, Seq((0, 2), (0, 2)))
@@ -219,57 +202,60 @@ class ProgressTrackerSuite extends SharedUtils {
   }
 
   test("inconsistent timestamp in the progress tracks can be detected") {
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
 
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2",
-      0 to 1, 0, 2)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3",
-      0 to 2, 0, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11",
-      0 to 0, 1, 2)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2", 0 to 1, 0, 2)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3", 0 to 2, 0, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11", 0 to 0, 1, 2)
+
     // write wrong record
     Files.write(
       Paths.get(progressPath + s"/progress-1000"),
       (ProgressRecord(2000L, "namespace2", "eh12", 0, 2, 3).toString + "\n").getBytes,
       StandardOpenOption.APPEND)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12",
-      1 to 1, 2, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13",
-      0 to 2, 3, 4)
+
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12", 1 to 1, 2, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13", 0 to 2, 3, 4)
 
     intercept[IllegalArgumentException] {
-      progressTracker.asInstanceOf[DirectDStreamProgressTracker].read("namespace2", 1000L,
-        fallBack = false)
+      progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+        .read("namespace2", 1000L, fallBack = false)
     }
   }
 
   test("snapshot progress tracking records can be read correctly") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+
     val eh1Partition0 = EventHubNameAndPartition("eh1", 0)
     val eh2Partition0 = EventHubNameAndPartition("eh2", 0)
     val connectedInstances = List(eh1Partition0, eh2Partition0)
     val connector1 = new DummyEventHubsConnector(0, "namespace1", connectedInstances)
     val connector2 = new DummyEventHubsConnector(0, "namespace2", connectedInstances)
+
     var progressWriter = new ProgressWriter(0, "namespace1", eh1Partition0,
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
+
     progressWriter = new ProgressWriter(0, "namespace1", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
+
     progressWriter = new ProgressWriter(0, "namespace2", eh1Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 10, 20)
+
     progressWriter = new ProgressWriter(0, "namespace2", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 20, 30)
-    val s = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
-      collectProgressRecordsForBatch(1000L, List(connector1, connector2))
+
+    val s = progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+      .collectProgressRecordsForBatch(1000L, List(connector1, connector2))
+
     assert(s.contains("namespace1"))
     assert(s.contains("namespace2"))
     assert(s("namespace1")(EventHubNameAndPartition("eh1", 0)) === (0, 1))
@@ -279,25 +265,31 @@ class ProgressTrackerSuite extends SharedUtils {
   }
 
   test("inconsistent timestamp in temp progress directory can be detected") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+
     val eh1Partition0 = EventHubNameAndPartition("eh1", 0)
     val eh2Partition0 = EventHubNameAndPartition("eh2", 0)
     val connectedInstances = List(eh1Partition0, eh2Partition0)
     val connector1 = new DummyEventHubsConnector(0, "namespace1", connectedInstances)
     val connector2 = new DummyEventHubsConnector(0, "namespace2", connectedInstances)
+
     var progressWriter = new ProgressWriter(0, "namespace1", eh1Partition0,
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
+
     progressWriter = new ProgressWriter(0, "namespace1", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 1)
+
     progressWriter = new ProgressWriter(0, "namespace2", eh1Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(2000L, 10, 20)
+
     progressWriter = new ProgressWriter(0, "namespace2", eh2Partition0, 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 20, 30)
+
     intercept[IllegalStateException] {
       progressTracker.asInstanceOf[DirectDStreamProgressTracker].
         collectProgressRecordsForBatch(1000L, List(connector1, connector2))
@@ -311,12 +303,15 @@ class ProgressTrackerSuite extends SharedUtils {
     var progressWriter = new ProgressWriter(0, "namespace1", EventHubNameAndPartition("eh1", 0),
       1000L, new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 0, 0)
+
     progressWriter = new ProgressWriter(0, "namespace1", EventHubNameAndPartition("eh2", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 1, 1)
+
     progressWriter = new ProgressWriter(0, "namespace2", EventHubNameAndPartition("eh1", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 2, 2)
+
     progressWriter = new ProgressWriter(0, "namespace2", EventHubNameAndPartition("eh2", 0), 1000L,
       new Configuration(), progressRootPath.toString, appName)
     progressWriter.write(1000L, 3, 3)
@@ -329,76 +324,63 @@ class ProgressTrackerSuite extends SharedUtils {
         EventHubNameAndPartition("eh1", 3) -> (2L, 2L),
         EventHubNameAndPartition("eh2", 4) -> (3L, 3L)))
     progressTracker.asInstanceOf[DirectDStreamProgressTracker].commit(offsetToCommit, 1000L)
+
     val namespace1Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
       read("namespace1", 1000L, fallBack = false)
+
     assert(namespace1Offsets === OffsetRecord(1000L, Map(
       EventHubNameAndPartition("eh1", 0) -> (0L, 0L),
       EventHubNameAndPartition("eh2", 1) -> (1L, 1L))))
+
     val namespace2Offsets = progressTracker.asInstanceOf[DirectDStreamProgressTracker].
       read("namespace2", 1000L, fallBack = false)
+
     assert(namespace2Offsets === OffsetRecord(1000L, Map(
       EventHubNameAndPartition("eh1", 3) -> (2L, 2L),
       EventHubNameAndPartition("eh2", 4) -> (3L, 3L))))
+
     // test temp directory cleanup
-    assert(fs.exists(new Path(PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName))))
-    assert(fs.listStatus(new Path(PathTools.progressTempDirPathStr(progressRootPath.toString,
-      appName))).length === 4)
+    assert(fs.exists(PathTools.makeTempDirectoryPath(
+      progressRootPath.toString, appName)))
+    assert(fs.listStatus(PathTools.makeTempDirectoryPath(
+      progressRootPath.toString, appName)).length === 4)
   }
 
   test("locate ProgressFile correctly") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString, appName,
-      new Configuration())
-    assert(progressTracker.asInstanceOf[DirectDStreamProgressTracker].
-      pinPointProgressFile(fs, 1000L) === None)
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+    assert(progressTracker.asInstanceOf[DirectDStreamProgressTracker]
+      .pinPointProgressFile(fs, 1000L) === None)
 
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
 
     // 1000
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2",
-      0 to 1, 0, 2)
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3",
-      0 to 2, 0, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11",
-      0 to 0, 1, 2)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12",
-      0 to 1, 2, 3)
-    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13",
-      0 to 2, 3, 4)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh2", 0 to 1, 0, 2)
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh3", 0 to 2, 0, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh11", 0 to 0, 1, 2)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh12", 0 to 1, 2, 3)
+    writeProgressFile(progressPath, 1, fs, 1000L, "namespace2", "eh13", 0 to 2, 3, 4)
 
     // 2000
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1",
-      0 to 0, 1, 2)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh2",
-      0 to 1, 1, 3)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh3",
-      0 to 2, 1, 4)
-    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh11",
-      0 to 0, 2, 3)
-    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh12",
-      0 to 1, 3, 4)
-    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh13",
-      0 to 2, 4, 5)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 1, 2)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh2", 0 to 1, 1, 3)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh3", 0 to 2, 1, 4)
+    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh11", 0 to 0, 2, 3)
+    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh12", 0 to 1, 3, 4)
+    writeProgressFile(progressPath, 1, fs, 2000L, "namespace2", "eh13", 0 to 2, 4, 5)
 
     // 3000
-    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh1",
-      0 to 0, 2, 3)
-    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh2",
-      0 to 1, 2, 4)
-    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh3",
-      0 to 2, 2, 5)
-    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh11",
-      0 to 0, 3, 4)
-    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh12",
-      0 to 1, 4, 5)
-    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh13",
-      0 to 2, 5, 6)
+    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh1", 0 to 0, 2, 3)
+    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh2", 0 to 1, 2, 4)
+    writeProgressFile(progressPath, 0, fs, 3000L, "namespace1", "eh3", 0 to 2, 2, 5)
+    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh11", 0 to 0, 3, 4)
+    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh12", 0 to 1, 4, 5)
+    writeProgressFile(progressPath, 1, fs, 3000L, "namespace2", "eh13", 0 to 2, 5, 6)
 
-    // if latest timestamp is earlier than the specified timestamp, we shall return the latest
-    // offsets
+    // if latest timestamp is earlier than the specified timestamp,
+    // then we shall return the latest offsets
     verifyProgressFile("namespace1", "eh1", 0 to 0, 4000L, Seq((2, 3)))
     verifyProgressFile("namespace1", "eh2", 0 to 1, 4000L, Seq((2, 4), (2, 4)))
     verifyProgressFile("namespace1", "eh3", 0 to 2, 4000L, Seq((2, 5), (2, 5), (2, 5)))
@@ -424,49 +406,59 @@ class ProgressTrackerSuite extends SharedUtils {
   }
 
   test("read progress file correctly when metadata exists") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString,
-      appName, new Configuration())
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    val metadataPath = PathTools.progressMetadataDirPathStr(progressRootPath.toString, appName)
+
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+
+    val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
     createMetadataFile(fs, metadataPath, 1000L)
+
     val result = progressTracker.read("namespace1", 1000, fallBack = true)
+
     assert(result.timestamp == 1000L)
     assert(result.offsets == Map(EventHubNameAndPartition("eh1", 0) -> (0, 1)))
   }
 
   test("ProgressTracker does query metadata when metadata exists") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString,
-      appName, new Configuration())
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    val metadataPath = PathTools.progressMetadataDirPathStr(progressRootPath.toString, appName)
+
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 0, 1)
+
+    val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
+
     createMetadataFile(fs, metadataPath, 1000L)
     createMetadataFile(fs, metadataPath, 2000L)
+
     val (sourceOfLatestFile, result) = progressTracker.getLatestFile(fs)
+
     assert(sourceOfLatestFile === 0)
     assert(result.isDefined)
     assert(result.get.getName === "progress-2000")
   }
 
   test("When metadata presents, we should respect it even the more recent progress file is there") {
-    progressTracker = DirectDStreamProgressTracker.initInstance(progressRootPath.toString,
-      appName, new Configuration())
-    val progressPath = PathTools.progressDirPathStr(progressRootPath.toString, appName)
+    progressTracker = DirectDStreamProgressTracker
+      .initInstance(progressRootPath.toString, appName, new Configuration())
+    val progressPath = PathTools.makeProgressDirectoryStr(progressRootPath.toString, appName)
     fs.mkdirs(new Path(progressPath))
-    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1",
-      0 to 0, 0, 1)
-    val metadataPath = PathTools.progressMetadataDirPathStr(progressRootPath.toString, appName)
+
+    writeProgressFile(progressPath, 0, fs, 1000L, "namespace1", "eh1", 0 to 0, 0, 1)
+    writeProgressFile(progressPath, 0, fs, 2000L, "namespace1", "eh1", 0 to 0, 0, 1)
+
+    val metadataPath = PathTools.makeMetadataDirectoryStr(progressRootPath.toString, appName)
     createMetadataFile(fs, metadataPath, 1000L)
+
     val (sourceOfLatestFile, result) = progressTracker.getLatestFile(fs)
+
     assert(sourceOfLatestFile === 0)
     assert(result.isDefined)
     assert(result.get.getName === "progress-1000")

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackerSuite.scala
@@ -56,9 +56,11 @@ class ProgressTrackerSuite extends SharedUtils {
       seq: Int): Unit = {
     for (partitionId <- partitionRange) {
       val filePath = Paths.get(progressPath + s"/${PathTools.makeProgressFileName(timestamp)}")
-      val stdOpenOption = if (Files.exists(filePath))
+      val stdOpenOption = if (Files.exists(filePath)) {
         StandardOpenOption.APPEND
-      else StandardOpenOption.CREATE
+      } else {
+        StandardOpenOption.CREATE
+      }
 
       Files.write(filePath,
         s"${ProgressRecord(timestamp, namespace, ehName, partitionId, offset, seq)

--- a/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/streaming/eventhubs/checkpoint/ProgressTrackingListenerSuite.scala
@@ -76,7 +76,7 @@ class ProgressTrackingListenerSuite extends SharedUtils {
     // build temp directories
     val progressWriter = new ProgressWriter(streamId, eventhubNamespace,
       EventHubNameAndPartition("eh1", 1), 1000L,
-      new Configuration(), progressTracker.progressTempDirectoryPath.toString,
+      new Configuration(), progressTracker.tempDirectoryPath.toString,
       appName)
     progressWriter.write(1000L, 0L, 0L)
     assert(fs.exists(progressWriter.tempProgressTrackingPointPath))

--- a/docs/ss.md
+++ b/docs/ss.md
@@ -46,7 +46,7 @@ import scala.concurrent.duration._
 val streamingQuery = inputStream.writeStream.
   format("parquet").
   outputMode(OutputMode.Append).
-  trigger(Trigger.ProcessingTime(10.seconds)).
+  trigger(Trigger.ProcessingTime(10 seconds)).
   option("checkpointLocation", checkpointLocation).
   option("path", outputPath + "/ETL").
   partitionBy("creationTime").

--- a/examples/src/main/scala/com/microsoft/spark/sql/examples/EventHubsStructuredStreamingExample.scala
+++ b/examples/src/main/scala/com/microsoft/spark/sql/examples/EventHubsStructuredStreamingExample.scala
@@ -17,8 +17,8 @@
 
 package com.microsoft.spark.sql.examples
 
-import org.apache.spark.sql.streaming.ProcessingTime
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.streaming.ProcessingTime
 import org.apache.spark.sql.functions._
 
 object EventHubsStructuredStreamingExample {

--- a/examples/src/main/scala/com/microsoft/spark/sql/examples/EventHubsStructuredStreamingExample.scala
+++ b/examples/src/main/scala/com/microsoft/spark/sql/examples/EventHubsStructuredStreamingExample.scala
@@ -18,8 +18,8 @@
 package com.microsoft.spark.sql.examples
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.streaming.ProcessingTime
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.streaming.ProcessingTime
 
 object EventHubsStructuredStreamingExample {
 

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>0.8.0</version>
         <configuration>
           <verbose>false</verbose>
           <failOnViolation>true</failOnViolation>

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
+        <version>2.15.2</version>
         <executions>
           <execution>
             <goals>
@@ -368,6 +369,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <executions>
           <execution>
             <id>empty-javadoc-jar</id>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>1.0.0</version>
         <configuration>
           <verbose>false</verbose>
           <failOnViolation>true</failOnViolation>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")


### PR DESCRIPTION
Slight cleanup to the code base. The following changes are made:
- cleaning up progress tracking files 
- updated scalastyle from 0.8.0 to 1.0.0
- made minor style updates (for example: removed semicolons, unneeded parentheses, incomplete javadoc comments, etc.) 
- updated pom.xml to remove some build warnings