### PR TITLE
Fix stale EventHubClient reuse on write when ReactorDispatcher is closed (#697)

### DIFF
--- a/core/src/main/scala/org/apache/spark/eventhubs/client/ClientConnectionPool.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/ClientConnectionPool.scala
@@ -41,6 +41,53 @@ private class ClientConnectionPool(val ehConf: EventHubsConf) extends Logging {
   private[this] val pool = new ConcurrentLinkedQueue[EventHubClient]()
   private[this] val count = new AtomicInteger(0)
 
+  private def createNewClient(): EventHubClient = {
+    val consumerGroup = ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)
+    logInfo(
+      s"No clients left to borrow. NamespaceUri: ${ehConf.namespaceUri}, EventHub name: ${ehConf.name}, " +
+        s"ConsumerGroup name: $consumerGroup. Creating client ${count.incrementAndGet()}")
+    val connStr = ConnectionStringBuilder(ehConf.connectionString)
+    connStr.setOperationTimeout(ehConf.receiverTimeout.getOrElse(DefaultReceiverTimeout))
+    EventHubsClient.userAgent =
+      s"SparkConnector-$SparkConnectorVersion-[${ehConf.name}]-[$consumerGroup]"
+    var client: EventHubClient = null
+    while (client == null) {
+      if (ehConf.useAadAuth) {
+        val ehClientOption: EventHubClientOptions = new EventHubClientOptions()
+          .setMaximumSilentTime(ehConf.maxSilentTime.getOrElse(DefaultMaxSilentTime))
+          .setOperationTimeout(ehConf.receiverTimeout.getOrElse(DefaultReceiverTimeout))
+          .setRetryPolicy(RetryPolicy.getDefault)
+        client = Await.result(
+          retryJava(
+            EventHubClient
+              .createWithAzureActiveDirectory(connStr.getEndpoint,
+                                              ehConf.name,
+                                              ehConf.aadAuthCallback().get,
+                                              ehConf.aadAuthCallback().get.authority,
+                                              ClientThreadPool.get(ehConf),
+                                              ehClientOption),
+            "createWithAzureActiveDirectory"
+          ),
+          ehConf.internalOperationTimeout
+        )
+      } else {
+        client = Await.result(
+          retryJava(
+            EventHubClient.createFromConnectionString(
+              connStr.toString,
+              RetryPolicy.getDefault,
+              ClientThreadPool.get(ehConf),
+              null,
+              ehConf.maxSilentTime.getOrElse(DefaultMaxSilentTime)),
+            "createFromConnectionString"
+          ),
+          ehConf.internalOperationTimeout
+        )
+      }
+    }
+    client
+  }
+
   /**
    * First, the connection pool is checked for available clients. If there
    * is a client available, that is given to the borrower. If the connection
@@ -52,47 +99,7 @@ private class ClientConnectionPool(val ehConf: EventHubsConf) extends Logging {
     var client = pool.poll()
     val consumerGroup = ehConf.consumerGroup.getOrElse(DefaultConsumerGroup)
     if (client == null) {
-      logInfo(
-        s"No clients left to borrow. NamespaceUri: ${ehConf.namespaceUri}, EventHub name: ${ehConf.name}, " +
-          s"ConsumerGroup name: $consumerGroup. Creating client ${count.incrementAndGet()}")
-      val connStr = ConnectionStringBuilder(ehConf.connectionString)
-      connStr.setOperationTimeout(ehConf.receiverTimeout.getOrElse(DefaultReceiverTimeout))
-      EventHubsClient.userAgent =
-        s"SparkConnector-$SparkConnectorVersion-[${ehConf.name}]-[$consumerGroup]"
-      while (client == null) {
-        if (ehConf.useAadAuth) {
-          val ehClientOption: EventHubClientOptions = new EventHubClientOptions()
-            .setMaximumSilentTime(ehConf.maxSilentTime.getOrElse(DefaultMaxSilentTime))
-            .setOperationTimeout(ehConf.receiverTimeout.getOrElse(DefaultReceiverTimeout))
-            .setRetryPolicy(RetryPolicy.getDefault)
-          client = Await.result(
-            retryJava(
-              EventHubClient
-                .createWithAzureActiveDirectory(connStr.getEndpoint,
-                                                ehConf.name,
-                                                ehConf.aadAuthCallback().get,
-                                                ehConf.aadAuthCallback().get.authority,
-                                                ClientThreadPool.get(ehConf),
-                                                ehClientOption),
-              "createWithAzureActiveDirectory"
-            ),
-            ehConf.internalOperationTimeout
-          )
-        } else {
-          client = Await.result(
-            retryJava(
-              EventHubClient.createFromConnectionString(
-                connStr.toString,
-                RetryPolicy.getDefault,
-                ClientThreadPool.get(ehConf),
-                null,
-                ehConf.maxSilentTime.getOrElse(DefaultMaxSilentTime)),
-              "createFromConnectionString"
-            ),
-            ehConf.internalOperationTimeout
-          )
-        }
-      }
+      client = createNewClient()
     } else {
       logInfo(
         s"Borrowing client. Namespace: ${ehConf.namespaceUri}, EventHub name: ${ehConf.name}, ConsumerGroup name: " +
@@ -103,15 +110,24 @@ private class ClientConnectionPool(val ehConf: EventHubsConf) extends Logging {
   }
 
   /**
-   * Returns the borrowed client to the connection pool.
+   * Returns the borrowed client to the connection pool. If [[forceRecreation]] is true,
+   * a new client is created and returned instead of the potentially stale one.
    *
    * @param client the [[EventHubClient]] being returned
+   * @param forceRecreation when true, discard the stale client and return a freshly created one
    */
-  private def returnClient(client: EventHubClient): Unit = {
-    pool.offer(client)
-    logInfo(
-      s"Client returned. Namespace: ${ehConf.namespaceUri},EventHub name: ${ehConf.name}. Total clients: ${count.get}. " +
-        s"Available clients: ${pool.size}")
+  private def returnClient(client: EventHubClient, forceRecreation: Boolean = false): Unit = {
+    if (forceRecreation) {
+      pool.offer(createNewClient())
+      logInfo(
+        s"Force-recreated client returned. Namespace: ${ehConf.namespaceUri}, EventHub name: ${ehConf.name}. " +
+          s"Total clients: ${count.get}. Available clients: ${pool.size}")
+    } else {
+      pool.offer(client)
+      logInfo(
+        s"Client returned. Namespace: ${ehConf.namespaceUri},EventHub name: ${ehConf.name}. Total clients: ${count.get}. " +
+          s"Available clients: ${pool.size}")
+    }
   }
 }
 
@@ -182,6 +198,20 @@ object ClientConnectionPool extends Logging {
     ensureInitialized(key(ehConf))
     val pool = get(key(ehConf))
     pool.returnClient(client)
+  }
+
+  /**
+   * Looks up the connection pool instance associated with the connection
+   * string in the provided [[EventHubsConf]], discards the stale [[EventHubClient]],
+   * and returns a freshly created client to the pool instead.
+   *
+   * @param ehConf the [[EventHubsConf]] used to lookup the connection pool
+   * @param client the stale [[EventHubClient]] being discarded
+   */
+  def reinstantiateAndReturnClient(ehConf: EventHubsConf, client: EventHubClient): Unit = {
+    ensureInitialized(key(ehConf))
+    val pool = get(key(ehConf))
+    pool.returnClient(client, forceRecreation = true)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
+++ b/core/src/main/scala/org/apache/spark/eventhubs/client/EventHubsClient.scala
@@ -225,7 +225,15 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
         logError(
           s"failed to complete pending tasks. event hubs: ${ehConf.name}, ${EventHubsUtils.getTaskContextSlim}",
           e)
-        cleanup()
+
+        val forceReinit = isReactorDispatcherError(e)
+        if (forceReinit) {
+          logWarn(
+            s"EventHubsClient send failed with ReactorDispatcher error: ${e.getMessage}. " +
+              s"Force recreating this client to ensure the stale connection is not reused. " +
+              s"event hubs: ${ehConf.name}, ${EventHubsUtils.getTaskContextSlim}")
+        }
+        cleanup(forceReinit)
 
         throw e
     }
@@ -233,7 +241,20 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
     Await.result(future, ehConf.internalOperationTimeout)
   }
 
-  private def cleanup(): Unit = {
+  /**
+   * Returns true if the exception indicates that the underlying ReactorDispatcher has been
+   * closed, making the [[EventHubClient]] non-functional. Follows the same detection pattern
+   * as the receiver-side fix in CachedEventHubsReceiver (PR #620).
+   */
+  private[client] def isReactorDispatcherError(e: Throwable): Boolean = {
+    val cause = e.getCause
+    cause != null &&
+    cause.isInstanceOf[java.util.concurrent.RejectedExecutionException] &&
+    cause.getMessage != null &&
+    cause.getMessage.contains("ReactorDispatcher instance is closed")
+  }
+
+  private def cleanup(forceReinitializeClient: Boolean = false): Unit = {
     pendingWorks.clear()
 
     if (partitionSender != null) {
@@ -242,7 +263,11 @@ private[spark] class EventHubsClient(private val ehConf: EventHubsConf)
     }
 
     if (_client != null) {
-      ClientConnectionPool.returnClient(ehConf, _client)
+      if (forceReinitializeClient) {
+        ClientConnectionPool.reinstantiateAndReturnClient(ehConf, _client)
+      } else {
+        ClientConnectionPool.returnClient(ehConf, _client)
+      }
       _client = null
     }
   }

--- a/core/src/test/scala/org/apache/spark/eventhubs/client/EventHubsClientSuite.scala
+++ b/core/src/test/scala/org/apache/spark/eventhubs/client/EventHubsClientSuite.scala
@@ -21,6 +21,9 @@
 
 package org.apache.spark.eventhubs.client
 
+import java.util.concurrent.{ CompletionException, RejectedExecutionException }
+
+import org.apache.spark.eventhubs.utils.EventHubsTestUtils
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, FunSuite }
 
@@ -36,4 +39,41 @@ class EventHubsClientSuite extends FunSuite with BeforeAndAfter with MockitoSuga
   test("EventHubsClient converts parameters for consumergroup") {}
 
   test("EventHubsClient converts parameters for enqueuetime filter") {}
+
+  // Tests for ReactorDispatcher stale-connection detection (issue #697)
+
+  private def makeClient(): EventHubsClient = {
+    val testUtils = new EventHubsTestUtils
+    val ehName = "isReactorDispatcherErrorTestEh"
+    testUtils.createEventHubs(ehName, partitionCount = 1)
+    val conf = testUtils.getEventHubsConfWithoutStartingPositions(ehName)
+    EventHubsClient(conf)
+  }
+
+  test("isReactorDispatcherError returns true for CompletionException caused by RejectedExecutionException with ReactorDispatcher message") {
+    val client = makeClient()
+    val cause = new RejectedExecutionException("ReactorDispatcher instance is closed.")
+    val e = new CompletionException(cause)
+    assert(client.isReactorDispatcherError(e))
+  }
+
+  test("isReactorDispatcherError returns false for CompletionException caused by RejectedExecutionException with unrelated message") {
+    val client = makeClient()
+    val cause = new RejectedExecutionException("executor is shut down")
+    val e = new CompletionException(cause)
+    assert(!client.isReactorDispatcherError(e))
+  }
+
+  test("isReactorDispatcherError returns false when exception cause is not a RejectedExecutionException") {
+    val client = makeClient()
+    val cause = new IllegalStateException("ReactorDispatcher instance is closed.")
+    val e = new CompletionException(cause)
+    assert(!client.isReactorDispatcherError(e))
+  }
+
+  test("isReactorDispatcherError returns false when exception has no cause") {
+    val client = makeClient()
+    val e = new RuntimeException("ReactorDispatcher instance is closed.")
+    assert(!client.isReactorDispatcherError(e))
+  }
 }


### PR DESCRIPTION
Fix stale EventHubClient reuse on write when ReactorDispatcher is closed
 
 When a send task fails with a CompletionException caused by
 RejectedExecutionException("ReactorDispatcher instance is closed"),
 the underlying EventHubClient is non-functional but was still being
 returned to the ClientConnectionPool and reused, causing repeated
 failures.
 
 This mirrors the fix applied on the receiver side in #620:
 detect the ReactorDispatcher error in EventHubsClient.close() and
 force-recreate a fresh client into the pool instead of returning
 the stale one.
 
 Changes:
 - ClientConnectionPool: extract createNewClient(); add
   reinstantiateAndReturnClient() to companion object; add
   forceRecreation flag to returnClient()
 - EventHubsClient: add isReactorDispatcherError() detection;
   add forceReinitializeClient flag to cleanup(); wire up in close()
 - EventHubsClientSuite: add unit tests for isReactorDispatcherError
 
 Fixes #697